### PR TITLE
Fix meta tags

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -20,6 +20,7 @@ const config: DocsThemeConfig = {
   feedback: {
     content: null,
   },
+  head: <></>,
   useNextSeoProps() {
     return {
       titleTemplate: "%s - Sei Docs",


### PR DESCRIPTION
There's a weird issue where the props are being set in `useNextSeoProps` below, but nextra overrides it with the default `head` values if this is not set