### PR TITLE
 move faucet information to developers section

### DIFF
--- a/pages/quickstart/_meta.json
+++ b/pages/quickstart/_meta.json
@@ -3,5 +3,6 @@
   "installing-seid": "Installing Seid",
   "tokenfactory-tutorial": "Token Factory Tutorial",
   "nft-contract-tutorial": "NFT Contract Tutorial",
-  "building-a-frontend": "Building a Frontend"
+  "building-a-frontend": "Building a Frontend",
+  "getting-testnet-tokens": "Getting Testnet Tokens"
 }

--- a/pages/quickstart/getting-testnet-tokens.mdx
+++ b/pages/quickstart/getting-testnet-tokens.mdx
@@ -1,0 +1,21 @@
+# Getting Testnet Sei Tokens
+
+### Faucets
+
+Faucets dispensing small amounts of tokens for development/testing are available on both the public testnet (atlantic-2) and devnet (arctic-1).
+
+These tokens bear no value, however please utilize small amounts when possible, as the supplied amounts are limited and the faucets all Discord-gated (unless specified).
+
+#### Sei Network provided
+
+- [Arctic-1 Devnet](https://arctic-1.app.sei.io/faucet)
+
+- [Atlantic-2 Testnet](https://atlantic-2.app.sei.io/faucet)
+
+#### Third-party
+
+- ['STAKEME' (Arctic-1 Devnet)](https://sei-evm.faucetme.pro/)
+
+- ['NIMA' (Arctic-1 Devnet)](https://sei-faucet.nima.enterprises/) (Github gated)
+
+For additional faucet resources, please refer to our [chain registry](https://github.com/sei-protocol/chain-registry/blob/main/chains.json).

--- a/pages/quickstart/nft-contract-tutorial.mdx
+++ b/pages/quickstart/nft-contract-tutorial.mdx
@@ -26,7 +26,7 @@ Before we start, ensure you have:
 
 <Callout type="info">
   You can obtain devnet tokens from one of the faucets listed
-  [here](/getting-tokens/faucets).
+  [here](/quickstart/getting-testnet-tokens).
 </Callout>
 
 ## Setting Up Your Project

--- a/pages/quickstart/tokenfactory-tutorial.mdx
+++ b/pages/quickstart/tokenfactory-tutorial.mdx
@@ -16,7 +16,7 @@ To create a token on the devnet, ensure you have the following setup:
 
 <Callout type="info">
   You can obtain devnet tokens from one of the faucets listed
-  [here](/getting-tokens/faucets).
+  [here](/quickstart/getting-testnet-tokens).
 </Callout>
 
 ## Creating a Denom

--- a/pages/user-guides/getting-tokens.mdx
+++ b/pages/user-guides/getting-tokens.mdx
@@ -21,22 +21,4 @@ Bridging is essential for transferring tokens between different blockchains. Thi
 
 For the best bridging experience, visit the [Sei Bridge page](https://app.sei.io/bridge).
 
-### Faucets
 
-Faucets dispensing small amounts of tokens for development/testing are available on both the public testnet (atlantic-2) and devnet (arctic-1).
-
-These tokens bear no value, however please utilize small amounts when possible, as the supplied amounts are limited and the faucets all Discord-gated (unless specified).
-
-#### Sei Network provided
-
-- [Arctic-1 Devnet](arctic-1.app.sei.io/faucet)
-
-- [Atlantic-2 Testnet](atlantic-2.app.sei.io/faucet)
-
-#### Third-party
-
-- ['STAKEME' (Arctic-1 Devnet)](https://sei-evm.faucetme.pro/)
-
-- ['NIMA' (Arctic-1 Devnet)](https://sei-faucet.nima.enterprises/) (Github gated)
-
-For additional faucet resources, please refer to our [chain registry](https://github.com/sei-protocol/chain-registry/blob/main/chains.json).


### PR DESCRIPTION
move faucet information to developers section
- move faucet info from users section to developer section
- add new page for faucet info to make it easier to find
- link to new page from tokenfactory and nft tutorials
- fix links on faucet page

Users should not generally be using testnets, and so this moves that information to the developers section.