### PR TITLE
Remove Rhino RPC from doc

### DIFF
--- a/pages/dev-ecosystem-providers/rpc-providers.mdx
+++ b/pages/dev-ecosystem-providers/rpc-providers.mdx
@@ -2,10 +2,6 @@
 
 RPC providers offer endpoints for developers to interact with the Sei blockchain, archive nodes, genesis files, and more. Some notable providers include:
 
-## **Rhino**:
-Provides robust RPC services for seamless blockchain interactions.
-   - [Rhino](https://rhinostake.com/#)
-
 ## **Quicknode**:
 A trusted infrastructure partner for the Sei network, providing developers with powerful APIs and dedicated support to streamline their blockchain applications.
    - [Quicknode](https://www.quicknode.com/)


### PR DESCRIPTION
## What is the purpose of the change?

Delete stale/incorrect documentation

## Describe the changes to the documentation

Removed Rhino RPC from list because Rhino doesn't support Sei anymore (at least for now: https://rhinostake.com/#OurNetworks)