### PR TITLE
Updates URLs and info for dev-pointer-contracts

### DIFF
--- a/pages/dev-tutorials/pointer-contracts.mdx
+++ b/pages/dev-tutorials/pointer-contracts.mdx
@@ -19,12 +19,12 @@ The list of requirements for deploying a pointer is fairly short:
 - Sei light client (CLI/daemon) installed on your machine. You can follow the [installation guide](./installing-seid.mdx) if needed.
 - Address for the relevant contract (the "pointee")
 
-When a pointer is registered for any given contract, the two are mapped and identifiable across both execution environments. This link is immutable and can only be changed by the original address that created it.
+When a pointer is registered for any given contract, the two are mapped and identifiable across both execution environments. This link is immutable and can only be changed through governance.
 
-Before deploying a pointer, you should first check if a pointer for the token/contract you wish to deploy already exists by running the following query:
+Before deploying a pointer, you should first check if a pointer for the token/contract you wish to deploy already exists, using this query:
 
 ```bash
-seid q evm pointer $TYPE $POINTEE --evm-rpc=https://evm-rpc.arctic-1.seinetwork.io/
+seid q evm pointer [type] [pointee] [flags]
 ```
 
 **Arguments**
@@ -41,7 +41,7 @@ seid q evm pointer $TYPE $POINTEE --evm-rpc=https://evm-rpc.arctic-1.seinetwork.
 To deploy a Pointer Contract that links to a CosmWasm contract, you can use the following command:
 
 ```bash
-seid tx evm register-evm-pointer [pointer type] [cw-address] --gas-fee-cap=<cap> --gas-limit=<limit> --evm-rpc=<rpc>
+seid tx evm register-evm-pointer [pointer type] [cw-address] --gas-fee-cap=<int> --gas-limit=<int>
 ```
 
 #### Arguments
@@ -59,8 +59,9 @@ seid tx evm register-evm-pointer [pointer type] [cw-address] --gas-fee-cap=<cap>
 
 After initially registering a pointer, it is advisable to confirm registration by using the following command:
 
-```bash
-seid query evm pointer [type] [pointee] [flags]
+```shell
+Usage:
+  seid query evm pointer [type] [pointee] [flags]
 ```
 
 #### Arguments
@@ -92,24 +93,24 @@ seid query evm pointer [type] [pointee] [flags]
 To deploy a CW20 Pointer Contract that links to an ERC20 token, you can use the following command:
 
 ```bash
-seid tx evm register-cw-pointer ERC20 $ERC20_TOKEN_ADDRESS --from=$SENDER --chain-id=arctic-1 --broadcast-mode=block --gas=200000 --fees=5000usei --node=https://rpc.arctic-1.seinetwork.io
+seid tx evm register-cw-pointer ERC20 $ERC20_TOKEN_ADDRESS --from=$SENDER --chain-id=pacific-1 --broadcast-mode=block --gas=200000 --fees=5000usei --node=https://rpc.sei-apis.com
 ```
 
 #### Arguments
 
-- `ERC20_TOKEN_ADDRESS`: The contract address of the ERC20 token you want to create a CW20 pointer for.
+- `ERC20_TOKEN_ADDRESS`: The contract address of the ERC20 contract to create a CW20 pointer for.
 
 #### Flags
 
 - `--from`: Keyfile (by name) from which the tx is sent. This address must have enough balance to cover transaction fees.
-- `--chain-id`: Identifies the specific chain of the Sei network you're interacting with. `arctic-1` refers to the Sei devnet.
+- `--chain-id`: Identifies the specific chain of the Sei network you're interacting with. `pacific-1` refers to the Sei mainnet.
 - `--broadcast-mode`: Determines how the transaction is broadcasted. Setting this to `block` means the transaction will wait to be included in a block before returning a response.
 - `--gas`: Specifies the maximum amount of gas that can be consumed by the transaction.
 - `--fees`: Indicates the transaction fee.
 - `--node`: Points to the specific Sei node RPC URL you're connecting to for transaction submission.
 
 <Callout type="info" emoji="ℹ️">
-  To check out the source code, please visit our [GitHub page](https://github.com/sei-protocol).
+  Source code for pointer contracts can be seen in the [contracts directory](https://github.com/sei-protocol/sei-chain/tree/main/contracts/src) of the [sei-chain](https://github.com/sei-protocol/sei-chain) repo.
 </Callout>
 
 ### For ERC721 Tokens
@@ -117,17 +118,17 @@ seid tx evm register-cw-pointer ERC20 $ERC20_TOKEN_ADDRESS --from=$SENDER --chai
 To deploy a CW721 Pointer Contract that links to an ERC721 token, you can use the following command:
 
 ```bash
-seid tx evm register-cw-pointer ERC721 $ERC721_TOKEN_ADDRESS --from=$SENDER --chain-id=arctic-1 --broadcast-mode=block --gas=200000 --fees=5000usei --node=https://rpc.arctic-1.seinetwork.io
+seid tx evm register-cw-pointer ERC721 $ERC721_TOKEN_ADDRESS --from=$SENDER --chain-id=pacific-1 --broadcast-mode=block --gas=200000 --fees=5000usei --node=https://rpc.sei-apis.com
 ```
 
 #### Arguments
 
-- `ERC721_TOKEN_ADDRESS`: The contract address of the ERC721 token you want to create a CW721 pointer for.
+- `ERC721_TOKEN_ADDRESS`: The contract address of the ERC721 token to create a CW721 pointer for.
 
 #### Flags
 
 - `--from`: Keyfile (by name) from which the tx is sent. This address must have enough balance to cover transaction fees.
-- `--chain-id`: Identifies the specific chain of the Sei network you're interacting with. `arctic-1` refers to the Sei devnet.
+- `--chain-id`: Identifies the specific chain of the Sei network you're interacting with. `pacific-1` refers to Sei mainnet.
 - `--broadcast-mode`: Determines how the transaction is broadcasted. Setting this to `block` means the transaction will wait to be included in a block before returning a response.
 - `--gas`: Specifies the maximum amount of gas that can be consumed by the transaction.
 - `--fees`: Indicates the transaction fee.
@@ -140,17 +141,17 @@ seid tx evm register-cw-pointer ERC721 $ERC721_TOKEN_ADDRESS --from=$SENDER --ch
 To deploy an ERC20 Pointer Contract that links to a CW20 token, you can use the following command:
 
 ```bash
-seid tx evm register-evm-pointer CW20 $CW20_TOKEN_ADDRESS --from=$SENDER --chain-id=arctic-1 --broadcast-mode=block --gas=200000 --fees=5000usei --node=https://rpc.arctic-1.seinetwork.io
+seid tx evm register-evm-pointer CW20 $CW20_TOKEN_ADDRESS --from=$SENDER --chain-id=pacific-1 --broadcast-mode=block --gas=200000 --fees=5000usei --node=https://rpc.sei-apis.com
 ```
 
 #### Arguments
 
-- `CW20_TOKEN_ADDRESS`: The contract address of the CW20 token you want to create an ERC20 pointer for.
+- `CW20_TOKEN_ADDRESS`: The contract address of the CW20 contract to create an ERC20 pointer for.
 
 #### Flags
 
 - `--from`: Keyfile (by name) from which the tx is sent. This address must have enough balance to cover transaction fees.
-- `--chain-id`: Identifies the specific chain of the Sei network you're interacting with. `arctic-1` refers to the Sei devnet.
+- `--chain-id`: Identifies the specific chain of the Sei network you're interacting with. `pacific-1` refers to Sei mainnet.
 - `--broadcast-mode`: Determines how the transaction is broadcasted. Setting this to `block` means the transaction will wait to be included in a block before returning a response.
 - `--gas`: Specifies the maximum amount of gas that can be consumed by the transaction.
 - `--fees`: Indicates the transaction fee.
@@ -161,17 +162,17 @@ seid tx evm register-evm-pointer CW20 $CW20_TOKEN_ADDRESS --from=$SENDER --chain
 To deploy an ERC721 Pointer Contract that links to a CW721 token, you can use the following command:
 
 ```bash
-seid tx evm register-evm-pointer CW721 $CW721_TOKEN_ADDRESS --from=$SENDER --chain-id=arctic-1 --broadcast-mode=block --gas=200000 --fees=5000usei --node=https://rpc.arctic-1.seinetwork.io
+seid tx evm register-evm-pointer CW721 $CW721_TOKEN_ADDRESS --from=$SENDER --chain-id=pacific-1 --broadcast-mode=block --gas=200000 --fees=5000usei --node=https://rpc.sei-apis.com
 ```
 
 #### Arguments
 
-- `CW721_TOKEN_ADDRESS`: The contract address of the CW721 token you want to create an ERC721 pointer for.
+- `CW721_TOKEN_ADDRESS`: The contract address of the CW721 token to create an ERC721 pointer for.
 
 #### Flags
 
 - `--from`: Keyfile (by name) from which the tx is sent. This address must have enough balance to cover transaction fees.
-- `--chain-id`: Identifies the specific chain of the Sei network you're interacting with. `arctic-1` refers to the Sei devnet.
+- `--chain-id`: Identifies the specific chain of the Sei network you're interacting with. `pacific-1` refers to Sei mainnet.
 - `--broadcast-mode`: Determines how the transaction is broadcasted. Setting this to `block` means the transaction will wait to be included in a block before returning a response.
 - `--gas`: Specifies the maximum amount of gas that can be consumed by the transaction.
 - `--fees`: Indicates the transaction fee.


### PR DESCRIPTION
## What is the purpose of the change?

Several minor fixes and updates 
 - Fix broken link to pointer reference [now leads directly to contract dir in `sei-chain` repo]
 - Change all `arctic-1` references >> `pacific-1`
 - Replace all devnet RPC URLs with rhino mainnet RPC URL
 - Remove `--evm-rpc` flag [does not exist]
 - Minor rephrase of some areas
 - Coirrected method of updating pointers 