### PR TITLE
Fixes broken syntax and odd styling

### DIFF
--- a/pages/dev-smart-contracts.mdx
+++ b/pages/dev-smart-contracts.mdx
@@ -17,7 +17,14 @@ When developing smart contracts on Sei, developers have the option to choose bet
 ### EVM
 The EVM is a decentralized computation engine that allows the execution of smart contracts on Ethereum and EVM-compatible blockchains. EVM contracts are typically written in Solidity, a language designed for Ethereum.
 
-<Paper shadow="lg" p="md" mt="xl" withBorder radius="md">
+<Paper
+  shadow="lg"
+  p="md"
+  mt="xl"
+  withBorder
+  radius="md"
+  className="bg-white text-black"
+>
 
 **Benefits**:
 
@@ -54,7 +61,15 @@ The EVM is a decentralized computation engine that allows the execution of smart
 
 CosmWasm is a smart contract platform built for the Cosmos ecosystem, enabling contracts to be written in WebAssembly (Wasm) languages, with Rust being the most commonly used.
 
-<Paper shadow="lg" p="md" mt="xl" withBorder radius="md">
+<Paper
+  shadow="lg"
+  p="md"
+  mt="xl"
+  withBorder
+  radius="md"
+  className="bg-white text-black"
+>
+
 **Benefits**:
 
 - **Language Flexibility**: Supports multiple programming languages that compile to Wasm, though Rust is preferred for its performance and safety features.

--- a/pages/dev-smart-contracts.mdx
+++ b/pages/dev-smart-contracts.mdx
@@ -48,6 +48,7 @@ The EVM is a decentralized computation engine that allows the execution of smart
   - [Wagmi Documentation](https://wagmi.sh/)
 - **Viem**: A lightweight and flexible library for Ethereum development.
   - [Viem Documentation](https://viem.sh/)
+</Paper>
 
 ### CosmWasm
 

--- a/pages/dev-smart-contracts.mdx
+++ b/pages/dev-smart-contracts.mdx
@@ -2,6 +2,7 @@ import {
    Blockquote, Paper, Title
 } from "@mantine/core";
 import { IconInfoCircle } from '@tabler/icons-react';
+import { Callout } from 'nextra/components'
 
 # Smart Contracts
 Smart contracts are self-executing contracts with their own state. On Sei, developers have the flexibility to use both the EVM (Ethereum Virtual Machine) and CosmWasm for smart contract development, allowing for a broad range of decentralized applications (dApps) and interoperability between the two ecosystems.
@@ -95,13 +96,13 @@ CosmWasm is a smart contract platform built for the Cosmos ecosystem, enabling c
 - **[CosmJS](https://cosmos.github.io/cosmjs/)**: JavaScript library for interacting with Cosmos blockchains.
 </Paper>
 
-<Blockquote color="blue" mt="xl" icon={<IconInfoCircle/>}>
+<Callout type="info" emoji="ℹ️">
    **Built in interoperability**:
    No matter which VM you choose, EVM and CosmWasm contracts can interact seamlessly with each other via two main mechanisms.
 
    - **EVM Precompile Contracts**: Precompiles are smart contracts pre-bundled into the chain. Sei has many precompiles to enable EVM dApps and contracts to access native Cosmos functions, such as staking and executing CosmWasm contracts.
    - **Pointer Contracts**: These contracts act as intermediaries, enabling calls between EVM and CosmWasm contracts. This allows developers to leverage the strengths of both environments and create more versatile dApps.
-</Blockquote>
+</Callout>
 
 ## Best Practices
 


### PR DESCRIPTION
`</paper>` was missing
regular styling for the `<paper>` block was unreadable, added some basic style here
changed out custom `<blockquote>` style callout to nextra-native callout