### PR TITLE
Update staking.mdx

### DIFF
--- a/pages/dev-interoperability/precompiles/staking.mdx
+++ b/pages/dev-interoperability/precompiles/staking.mdx
@@ -25,7 +25,7 @@ This precompile allows EVM contracts to interact with Sei's staking module, enab
 
   ```solidity
   /// Redelegates Sei from one validator to another.
-  /// @dev The amount should be in 6 decimal precision, not 18
+  /// @dev The amount should be in 6 decimal precision, not 18. 1 SEI = 1_000_000 uSEI
   /// @param srcAddress The Sei address of the validator to move delegations from.
   /// @param dstAddress The Sei address of the validator to move delegations to.
   /// @param amount The amount of Sei to move from srcAddress to dstAddress.
@@ -40,7 +40,7 @@ This precompile allows EVM contracts to interact with Sei's staking module, enab
 - `undelegate`: Provides the functionality for a user to withdraw a specified amount of tokens from a validator
   ```solidity
   /// Undelegates Sei from the specified validator.
-  /// @dev The amount should be in 6 decimal precision, not 18
+  /// @dev The amount should be in 6 decimal precision, not 18. 1 SEI = 1_000_000 uSEI
   /// @param valAddress The Sei address of the validator to undelegate from.
   /// @param amount The amount of Sei to undelegate.
   /// @return Whether the undelegation was successful.

--- a/pages/dev-interoperability/precompiles/staking.mdx
+++ b/pages/dev-interoperability/precompiles/staking.mdx
@@ -9,10 +9,11 @@ This precompile allows EVM contracts to interact with Sei's staking module, enab
 ## Functions
 
 ### Transactions
-- `delegate`: Allows a user to delegate a specified amount of tokens to a validator
+- `delegate`: Allows a user to delegate a specified amount of tokens to a validator. This function will truncate the `msg.value` to 6 decimals to 
 
   ```solidity
   /// Delegates Sei to the specified validator.
+  /// @dev This function truncates msg.value to 6 decimal places for interaction with the staking module
   /// @param valAddress The Sei address of the validator.
   /// @return Whether the delegation was successful.
   function delegate(
@@ -24,6 +25,7 @@ This precompile allows EVM contracts to interact with Sei's staking module, enab
 
   ```solidity
   /// Redelegates Sei from one validator to another.
+  /// @dev The amount should be in 6 decimal precision, not 18
   /// @param srcAddress The Sei address of the validator to move delegations from.
   /// @param dstAddress The Sei address of the validator to move delegations to.
   /// @param amount The amount of Sei to move from srcAddress to dstAddress.
@@ -38,6 +40,7 @@ This precompile allows EVM contracts to interact with Sei's staking module, enab
 - `undelegate`: Provides the functionality for a user to withdraw a specified amount of tokens from a validator
   ```solidity
   /// Undelegates Sei from the specified validator.
+  /// @dev The amount should be in 6 decimal precision, not 18
   /// @param valAddress The Sei address of the validator to undelegate from.
   /// @param amount The amount of Sei to undelegate.
   /// @return Whether the undelegation was successful.


### PR DESCRIPTION
## What is the purpose of the change?

Added details about staking precompile that were missing

## Describe the changes to the documentation

Explained how precompiles truncate `msg.value` for `payable` function and details about what amount to send while interacting with `redelegate` and `undelegate` function.

## Notes

None