### PR TITLE
Update wallets.mdx to add Arculus to recommended wallets

### DIFF
--- a/pages/dev-ecosystem-providers/wallets.mdx
+++ b/pages/dev-ecosystem-providers/wallets.mdx
@@ -12,6 +12,7 @@ Wallets are essential for managing assets and interacting with the Sei blockchai
 
 | Wallet                         | EVM Support | Native Support | Authentication Method | Coin Type | Type     | Mobile Support | Link                                                                                          |
 |--------------------------------|-------------|----------------|-----------------------|-----------|----------|----------------|-----------------------------------------------------------------------------------------------|
+| **Arculus**                    | ✅           | ✅              | Hardware             | 118 / 60  | Software | ✅              | [Arculus](https://www.getarculus.com)                                                     |
 | **Compass**                    | ✅           | ✅              | Mnemonic / Privkey    | 118       | Software | ✅              | [Compass Wallet](https://compasswallet.io)                                                     |
 | **Fin**                        | ✅           | ✅              | Mnemonic / Privkey    | 118       | Software | ❌              | [Fin Wallet](https://finwallet.com)                                                            |
 | **Keplr**                      | ✅           | ✅              | Mnemonic / Privkey    | 118       | Software | ✅              | [Keplr Wallet](https://wallet.keplr.app)                                                       |


### PR DESCRIPTION
Arculus worked with the Sei team to add native support for the both the type 60 and type 118 natively to the Arculus hardware wallet.

## What is the purpose of the change?

<!-- Is this PR to correct existing documentation, add new content, or delete stale/incorrect documentation? -->
Add new content. There were no hardware wallets in the recommended list that directly support Sei without having to attach a hardware device to a different wallet. Arculus is a easy to use solution that should be recommended.

## Describe the changes to the documentation

<!-- A brief description of the changes in this PR and why they are required. If adding new content, be sure to detail the target audience of the new documentation-->
Added an Arculus line to recommended wallets following the existing alphabetical ordering.

## Notes
<!-- Optional section for any other notes in this PR -->
Arculus team worked directly with the Sei team to add this support.