### PR TITLE
fix node version table

### DIFF
--- a/pages/dev-node/node-operators.mdx
+++ b/pages/dev-node/node-operators.mdx
@@ -1,14 +1,20 @@
+import VersionTable from '../../components/VersionFetcher/VersionTable';
+
 # Sei Node Setup
 
 ## System Requirements
 
 | CPU Cores | RAM  | Disk     |
-|-----------|------|----------|
+| --------- | ---- | -------- |
 | 16 cores  | 64GB | 1TB NVMe |
+
+### Build Version and Genesis Table
+
+<VersionTable />
 
 ## Getting Started
 
-*The following instructions are for Debian-based systems. Other operating systems like macOS or Arch will use a slightly different procedure.*
+_The following instructions are for Debian-based systems. Other operating systems like macOS or Arch will use a slightly different procedure._
 
 ### Update and Upgrade System Packages
 


### PR DESCRIPTION
Re-adds version table I mistakenly removed from /dev/node-operators