### PR TITLE
adds oracle setup to validator ops, removes redundant language from headers

### DIFF
--- a/STYLE_GUIDE.mdx
+++ b/STYLE_GUIDE.mdx
@@ -7,19 +7,20 @@ This style guide contains general rules and principles to ensure the documentati
 This documentation strives to be
 
 ### Beginner Friendly
+
 The Sei community welcomes members from all walks of life. As such, the documentation should be understandable by anyone, including those who are new to Web3 or non-technical.
 
 The docs should strive to be Jargon Free
+
 - Advanced terms and concepts, especially Web3 related terms and ideas, should be properly explained.
 - Where appropriate, we should provide links to resources that can help the reader understand.
 - Acronyms should be spelled out
-
 
 ### Simple
 
 Great documentation is simple and to the point. It should aim to convey more meaning with less words.
 
-- To be clear and inclusive, avoid using jargon and obscure words where possible. 
+- To be clear and inclusive, avoid using jargon and obscure words where possible.
 - Limit the number of clauses in a sentence and make sure that your points are structured.
 - Avoid qualifying language, which is ~~quite~~ often ~~completely~~ unnecessary.
 - Information should be simply organized and easy to find.
@@ -27,6 +28,7 @@ Great documentation is simple and to the point. It should aim to convey more mea
 ### Self-explanatory
 
 Great documentation is self-explanatory. Documentation shouldn't need more documentation to explain itself.
+
 - Aim to provide as much context as possible. Code snippets and diagrams are great ways to illustrate complex concepts and provide examples.
 
 ## Organization
@@ -34,30 +36,38 @@ Great documentation is self-explanatory. Documentation shouldn't need more docum
 The Sei Docs are structured using the [Nextra](https://nextra.site). Are a guideline, we have split the pages by target audience.
 
 ### General
+
 Docs in these section describe Sei and topics that are applicable to all audiences. This is general information that is not specific to users or developers. Information here is meant to be as layman as possible and should be understandable by everyone.
 
 Information here might include:
+
 - What is Sei?
 - How does a blockchain work?
 - General information about how things work.
 
 ### For Users
+
 This section includes information specific to enabling people to interact with the Sei blockchain.
 
 Examples include information about standard resources used to interact with the chain (Wallets, Block Explorers), as well as tutorials on how to get started on Sei (Where to find tokens, apps etc.)
 
 ### For Devs
+
 This section includes resources for developers looking to build Dapps on Sei. Examples of what goes in here include:
+
 - Smart contract tutorials
 - Endpoints and config information that developers should use to interact with Sei (RPC Endpoints, Chain IDs etc)
 - Information about clients and libraries that developers can use to easily develop apps.
 
 ### Advanced
+
 This section covers topics that are more specific to chain infrastructure. These are topics that are typically abstracted away from regular users and developers, but might be relevant to those looking to contribute chain infrastructure. Examples of topics here include:
+
 - How to run a Sei Node
 - How to run a Sei Validator
 
 ### Misc
+
 This section houses other pages that do not fall under the buckets above.
 
 ## Style guidelines
@@ -65,11 +75,13 @@ This section houses other pages that do not fall under the buckets above.
 ### Acronyms and Abbreviations
 
 To maximize clarity, we should avoid Acronyms and Abbreviations where possible, especially for shorter, more ambiguous acronyms
+
 - Just use 'CosmWasm' instead of 'CW'
 
-However, there are occasions where acronyms might be more easily understandable (Eg. NFT instead of Non-Fungible Token, RPC instead of Remote Procedure Call), or referred to very frequently. 
+However, there are occasions where acronyms might be more easily understandable (Eg. NFT instead of Non-Fungible Token, RPC instead of Remote Procedure Call), or referred to very frequently.
 
 In these cases, we should first use the use the spelled-out term followed by the shortened form in parentheses.
+
 - Command Line Interface (CLI)
 - Denomination (Denom)
 
@@ -77,29 +89,36 @@ On subsequent occurrences in the same topic, we can then use the acronym.
 
 ### Links
 
-You can add links to text using the followings syntax 
+You can add links to text using the followings syntax
+
 ```md
 [text_to_highlight](link)
 ```
 
 Some examples (These examples assume the page is in the `/pages` directory):
+
 1. Link to section of [same document](#style-guidelines).
+
 ```md
 [same document](#style-guidelines)
 ```
 
-2. Link to [another document](/pages/overview.mdx).
+2. Link to [another document](/pages/overview).
+
 ```md
 # Path is relative
+
 [another document](/overview)
 ```
 
 3. Link to [section of another document](/pages/overview.mdx#Staking).
+
 ```md
 [section of another document](/overview#Staking)
 ```
 
 4. External [Link](www.app.sei.io).
+
 ```md
 [Link](www.app.sei.io)
 ```
@@ -112,38 +131,44 @@ Links should be as descriptive as possible to let the reader know where they are
 
 - Better Example: Interested to learn more about staking? Refer to our [staking guide](#links) to find out more!
 
-
 ### Code
+
 Code should either be specified as `inline`
+
 ```md
 Code should either be specified as `inline`
 ```
 
 Or within code blocks.
+
 ```ts
-const codeBlockString = "codeBlock"
+const codeBlockString = 'codeBlock';
 ```
 
-```md
+````md
     ```ts
     const codeBlockString = "codeBlock"
     ```
-```
+````
 
 `Inline Code` should be used when referring to
+
 - File and directory names. (eg. `./pages/overview.mdx`)
 - References to variables in code (eg. `codeBlockString`)
 
 Code Blocks should be used when
+
 - Sharing code snippets
+
 ```ts
 const codeBlockString = () => {
-    const text = "codeblock"
-    let codeBlockSize: Number = 1
-}
+  const text = 'codeblock';
+  let codeBlockSize: Number = 1;
+};
 ```
 
 - Scripts that users should copy and execute directly
+
 ```sh
 git clone https://github.com/sei-protocol/sei-chain
 cd sei-chain
@@ -152,7 +177,8 @@ make install
 ```
 
 When code blocks are used, they should always be prettified by specifying the language. For example:
-```md
+
+````md
     TypeScript code block labelled with 'ts'
     ```ts
     const variable = value;
@@ -163,9 +189,10 @@ When code blocks are used, they should always be prettified by specifying the la
     git clone https://github.com/sei-protocol/sei-chain
     cd sei-chain
     ```
-```
+````
 
 When writing code blocks, avoid
+
 1. Creating large code blocks. Break your code into smaller, more digestible pieces.
 2. Writing too much documentation in between lines. If necessary, break the code block up and add text to explain each code block instead.
 
@@ -184,18 +211,20 @@ Headings should be use to denote the start of each section. There are 4 levels o
 #### Use only if more required
 ```
 
-Headings levels should never be skipped. A level 2 heading should follow a level 1 heading, and a level 3 heading should follow a level 2 heading etc.  
+Headings levels should never be skipped. A level 2 heading should follow a level 1 heading, and a level 3 heading should follow a level 2 heading etc.
 
 ### Images
 
 To use images, first add them to the `./public/assets` folder.
 
 Afterwards, they can be imported in each page using an import statement. For example:
+
 ```md
 import nameOfImage from "../../public/assets/nameOfImage.png";
 ```
 
 Lastly, use the `ImageWithCaption` component to add the image to the page, along with a descriptive label:
+
 ```md
 <ImageWithCaption img={nameOfImage} alt="alt text for my image" caption="Your caption here" />
 ```

--- a/data/redirects.json
+++ b/data/redirects.json
@@ -400,7 +400,7 @@
 		"permanent": true
 	},
 	{
-		"source": "/dev-ecosystem-providers/wallets",
+		"source": "/providers/wallets/wallets",
 		"destination": "/providers/wallets",
 		"permanent": true
 	},

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"start": "next start",
 		"format:pages": "prettier --write 'pages/**/*.{js,ts,tsx,mdx}'",
 		"generate-seid-docs": "./generate-seid-docs.sh",
-		"check-links": "concurrently \"next start\" \"wait-on http://localhost:3000 && node scripts/check-links.mjs\" --kill-others --success first"
+		"check-links": "node scripts/check-links.mjs"
 	},
 	"license": "MIT",
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -52,5 +52,6 @@
 		"tailwindcss": "^3.4.1",
 		"typescript": "^5.3.3",
 		"wait-on": "^8.0.2"
-	}
+	},
+	"packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,5 @@
 		"tailwindcss": "^3.4.1",
 		"typescript": "^5.3.3",
 		"wait-on": "^8.0.2"
-	},
-	"packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+	}
 }

--- a/pages/build/building-a-frontend.mdx
+++ b/pages/build/building-a-frontend.mdx
@@ -25,10 +25,7 @@ We will use [ethers.js](https://docs.ethers.org/v6/) to build a React app that i
 Before starting, ensure you have:
 
 - Node.js & NPM installed
-- One of the Sei wallets listed [here](../providers/wallets/wallets)
-- The wallet should be funded with sufficient Sei on our devnet (arctic-1).
-  Refer to the section on [faucets](../dev-ecosystem-providers/faucets) for
-  instructions on how to get Devnet tokens.
+- One of the Sei wallets listed [here](providers/wallets/wallets)
 
 ## Creating a React Project
 
@@ -61,7 +58,7 @@ are EVM compatible contracts that are built into the chain.
 The Wasm Precompile
 is a unique smart contract on Sei that enables EVM clients to query and execute
 CosmWasm contracts. Refer to the docs on
-[precompiles](pages/reference/precompiles/example-usage.mdx) for
+[precompiles](reference/precompiles/example-usage) for
 more details.
 
 First, import the address and ABI of the CosmWasm precompile from `@sei-js/evm`.
@@ -444,7 +441,7 @@ and increment it with an execute message.
 Run `npm run dev` and navigate to http://localhost:5173/ to view your
 application.
 
-<Callout type="info">If this is your first time using Sei, you might see an error which says your account does not exist on chain. You can claim some testnet tokens for development purposes from a faucet [here](/getting-tokens/faucets).</Callout>
+<Callout type="info">If this is your first time using Sei, you might see an error which says your account does not exist on chain. You can claim some testnet tokens for development purposes from a faucet [here](https://t.me/+31M9Ig2z2-w2OTdk).</Callout>
 
 </Tabs.Tab>
 </Tabs>

--- a/pages/build/building-a-frontend.mdx
+++ b/pages/build/building-a-frontend.mdx
@@ -13,11 +13,11 @@ Select one of the tabs below to get started!
 <Tabs items={["EVM", "CosmWasm"]}>
 <Tabs.Tab>
 In this section, we'll explore Sei's unique interoperability features by building an EVM compatible DApp that interacts with a CosmWasm smart contract.
-We will use [ethers.js](https://docs.ethers.org/v6/) to build a React app that interacts with a CosmWasm smart contract using the Sei [CosmWasm precompile](../dev-advanced-concepts/interoperability/precompiles/cosmwasm.mdx).
+We will use [ethers.js](https://docs.ethers.org/v6/) to build a React app that interacts with a CosmWasm smart contract using the Sei [CosmWasm precompile](https://github.com/sei-protocol/sei-chain/tree/main/precompiles/wasmd).
 
 ## Prerequisites
 
-- Complete the tutorial in [cosmwasm-general](./cosmwasm-general.mdx) to deploy
+- Complete the tutorial in [cosmwasm-general](build/cosmwasm-general) to deploy
   a CosmWasm counter contract on our devnet (arctic-1).
 
 ## Requirements
@@ -25,9 +25,9 @@ We will use [ethers.js](https://docs.ethers.org/v6/) to build a React app that i
 Before starting, ensure you have:
 
 - Node.js & NPM installed
-- One of the Sei wallets listed [here](../dev-ecosystem-providers/wallets.mdx)
+- One of the Sei wallets listed [here](../providers/wallets/wallets)
 - The wallet should be funded with sufficient Sei on our devnet (arctic-1).
-  Refer to the section on [faucets](../dev-ecosystem-providers/faucets.mdx) for
+  Refer to the section on [faucets](../dev-ecosystem-providers/faucets) for
   instructions on how to get Devnet tokens.
 
 ## Creating a React Project
@@ -57,11 +57,12 @@ npm install ethers
 
 In this tutorial, we will be using the **Wasm Precompile** to interact with our
 CosmWasm contract from the EVM. Precompiles (short for Precompiled contracts)
-are EVM compatible contracts that are built into the chain. The Wasm Precompile
+are EVM compatible contracts that are built into the chain.
+The Wasm Precompile
 is a unique smart contract on Sei that enables EVM clients to query and execute
 CosmWasm contracts. Refer to the docs on
-[interoperability](../dev-advanced-concepts/interoperability/introduction) for
-more details about precompiles.
+[precompiles](pages/reference/precompiles/example-usage.mdx) for
+more details.
 
 First, import the address and ABI of the CosmWasm precompile from `@sei-js/evm`.
 
@@ -448,8 +449,276 @@ application.
 </Tabs.Tab>
 </Tabs>
 
-## Conclusion
-
 🎉 Congratulations on creating a website for querying and executing a smart
 contract on Sei! Explore more possibilities with your frontend at our
 [@sei-js repo](https://github.com/sei-protocol/sei-js/tree/main).
+
+## Beyond Simple Contracts: Advanced CosmWasm Interactions
+
+While our counter example demonstrated the basics of connecting to and interacting with a CosmWasm contract through the WASM precompile, CosmWasm contracts offer much more sophisticated capabilities. One of their most powerful features is their ability to describe their own interfaces, eliminating the need for external ABIs (Application Binary Interfaces) that are typically required for EVM contract interactions.
+
+Let's explore these advanced features by building a component that interacts with a CW721 (NFT) contract. This example will demonstrate contract discovery, handling different response formats, and implementing robust error handling - skills that are essential when working with more complex CosmWasm contracts.
+
+# Advanced CosmWasm Contract Interactions Through the WASM Precompile
+
+## Introduction
+
+While our basic counter example demonstrated simple contract interactions, CosmWasm contracts offer much more sophisticated capabilities than traditional EVM contracts. One of their most powerful features is their ability to describe their own interfaces, eliminating the need for external ABIs (Application Binary Interfaces) that are required for EVM contract interactions.
+
+In this guide, we'll explore these advanced features and learn how to build more complex applications that leverage the full power of CosmWasm contracts through Sei's WASM precompile.
+
+## Understanding CosmWasm Contract Discovery
+
+Unlike EVM contracts where you need detailed interface specifications beforehand, CosmWasm contracts can tell you exactly how to interact with them. This self-describing capability makes them particularly developer-friendly and reduces the chance of interface mismatches.
+
+Let's explore how to implement this discovery mechanism:
+
+```typescript
+async function discoverContractMethods(contractAddress: string) {
+  // We intentionally send an invalid query - the contract will respond with valid methods
+  const invalidQuery = { a: 'b' };
+
+  try {
+    await contract.query(contractAddress, toUtf8Bytes(JSON.stringify(invalidQuery)));
+    // If we reach here, something unexpected happened
+    console.log('Unexpected success - contract accepted invalid query');
+    return null;
+  } catch (error) {
+    if (error.data) {
+      const errorMessage = toUtf8String(error.data);
+
+      // The error message contains a list of valid methods
+      // Format: "expected one of method1, method2, method3: query wasm contract failed"
+      const match = errorMessage.match(/expected one of (.+): query wasm contract failed/);
+      if (match) {
+        const validMethods = match[1]
+          .replace(/`/g, '')
+          .split(', ')
+          .map((method) => method.trim());
+        console.log('Valid query methods:', validMethods);
+        return validMethods;
+      }
+    }
+    console.error('Unexpected error structure:', error);
+    return null;
+  }
+}
+```
+
+When we run this against a CW721 (NFT) contract, we might receive a response like this:
+
+```javascript
+[
+  'owner_of', // Query the owner of a specific token
+  'approval', // Check if an address is approved for a token
+  'approvals', // List all approvals for a token
+  'operator', // Check if an address is an operator
+  'all_operators', // List all operators
+  'num_tokens', // Get total supply of tokens
+  'contract_info', // Get contract metadata
+  'nft_info', // Get metadata for a specific token
+  'all_nft_info', // Get all info for a specific token
+  'tokens', // List tokens owned by an address
+  'all_tokens', // List all tokens in the collection
+  'minter', // Get the minting authority
+  'extension', // Access CW721 extensions
+  'ownership' // Query contract ownership
+];
+```
+
+## Building an NFT Information Component
+
+Let's create a practical example that uses these discovered methods to interact with a CW721 contract. This component will display both collection-wide information and individual token details:
+
+```typescript
+function NFTViewer() {
+  const [methods, setMethods] = useState<string[]>([]);
+  const [collectionOwner, setCollectionOwner] = useState<string>();
+  const [tokenOwner, setTokenOwner] = useState<string>();
+  const [contract, setContract] = useState<Contract>();
+  const [tokenId, setTokenId] = useState<string>('1');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const NFT_CONTRACT_ADDRESS = "sei1g2a0q3tddzs7vf7lk45c2tgufsaqerxmsdr2cprth3mjtuqxm60qdmravc";
+
+  // Query collection ownership
+  const queryCollectionOwner = async () => {
+    try {
+      // The ownership query returns collection-level ownership information
+      const queryMsg = { ownership: {} };
+      const queryResponse = await contract.query(
+        NFT_CONTRACT_ADDRESS,
+        toUtf8Bytes(JSON.stringify(queryMsg))
+      );
+      const responseData = JSON.parse(toUtf8String(queryResponse));
+
+      // Handle different response formats - some contracts nest data differently
+      const owner = responseData.data?.owner || responseData.owner;
+      setCollectionOwner(owner);
+    } catch (error) {
+      console.error('Error querying collection owner:', error);
+    }
+  };
+
+  // Query specific token ownership
+  const queryTokenOwner = async (tokenId: string) => {
+    try {
+      setIsLoading(true);
+      // The owner_of query returns ownership information for a specific token
+      const queryMsg = { owner_of: { token_id: tokenId } };
+      const queryResponse = await contract.query(
+        NFT_CONTRACT_ADDRESS,
+        toUtf8Bytes(JSON.stringify(queryMsg))
+      );
+      const responseData = JSON.parse(toUtf8String(queryResponse));
+      const owner = responseData.data?.owner || responseData.owner;
+      setTokenOwner(owner);
+    } catch (error) {
+      console.error('Error querying token owner:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Discover available methods when component mounts or contract changes
+  useEffect(() => {
+    if (!contract) return;
+    discoverContractMethods(NFT_CONTRACT_ADDRESS)
+      .then(setMethods);
+  }, [contract]);
+
+  return (
+    <div className="nft-viewer">
+      <h2>NFT Collection Info</h2>
+      <div>
+        <p>Collection Address: {NFT_CONTRACT_ADDRESS}</p>
+        <p>Collection Owner: {collectionOwner || 'Loading...'}</p>
+        <p>Available Methods: {methods?.join(', ') || 'Loading...'}</p>
+      </div>
+
+      <div className="token-lookup">
+        <h3>Token Ownership Lookup</h3>
+        <div className="input-group">
+          <input
+            type="text"
+            value={tokenId}
+            onChange={(e) => setTokenId(e.target.value)}
+            placeholder="Enter token ID"
+          />
+          <button
+            onClick={() => queryTokenOwner(tokenId)}
+            disabled={isLoading}
+          >
+            {isLoading ? 'Searching...' : 'Look Up Token'}
+          </button>
+        </div>
+        {tokenOwner && (
+          <div className="token-result">
+            <p>Token {tokenId} Owner: {tokenOwner}</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+## Understanding CosmWasm Response Formats
+
+CosmWasm contracts can return data in various formats, and it's important to handle these variations properly. Here are some example responses you might receive:
+
+- Collection Ownership Query Response:
+
+```json
+{
+  "owner": "sei1hjsqrfdg2hvwl3gacg4fkznurf36usrv7rkzkyh29wz3guuzeh0snslz7d",
+  "pending_owner": null,
+  "pending_expiry": null
+}
+```
+
+- Token Ownership Query Response:
+
+```json
+{
+  "owner": "sei1frcndtm928xln5awxz4rcrh3f5exskjczrc92f",
+  "approvals": []
+}
+```
+
+Notice how these responses have different structures. That's why our code uses a flexible approach to extract the owner:
+
+```typescript
+const owner = responseData.data?.owner || responseData.owner;
+```
+
+## Creating a Reusable Query Function
+
+To make contract interactions more maintainable, consider creating a reusable query function:
+
+```typescript
+async function queryContract(address: string, queryMsg: object) {
+  try {
+    const response = await contract.query(address, toUtf8Bytes(JSON.stringify(queryMsg)));
+
+    const result = JSON.parse(toUtf8String(response));
+    // Handle both nested and direct data structures
+    return result.data ?? result;
+  } catch (error) {
+    if (error.data) {
+      const errorMessage = toUtf8String(error.data);
+      // Check if this is a method discovery error
+      if (errorMessage.includes('expected one of')) {
+        console.log('Available methods:', errorMessage);
+      }
+    }
+    throw error;
+  }
+}
+```
+
+## Best Practices for CosmWasm Contract Interactions
+
+When building applications that interact with CosmWasm contracts through the WASM precompile, follow these guidelines:
+
+1. **Always Start with Discovery**: Use the contract's self-describing capabilities to understand its interface. This prevents errors and makes your code more maintainable.
+
+2. **Handle Response Variations**: CosmWasm contracts might return data in different formats. Always implement robust response parsing that can handle various structures.
+
+3. **Implement Proper Error Handling**: CosmWasm contracts provide detailed error messages that can help diagnose issues. Make use of this information in your error handling.
+
+4. **Manage Loading States**: Always provide clear feedback about the state of contract interactions to improve user experience.
+
+5. **Cache Method Information**: Consider caching the discovered methods to reduce unnecessary queries, but make sure to refresh this cache periodically.
+
+## Error Handling Examples
+
+Here's how to handle different types of errors you might encounter:
+
+```typescript
+try {
+  const result = await queryContract(address, queryMsg);
+  // Handle success
+} catch (error) {
+  if (error.data) {
+    const errorMessage = toUtf8String(error.data);
+    if (errorMessage.includes('expected one of')) {
+      // This is a method discovery error - might be useful!
+      console.log('Valid methods:', errorMessage);
+    } else if (errorMessage.includes('not found')) {
+      // Handle non-existent tokens or resources
+      console.log('Resource not found');
+    } else {
+      // Handle other contract-specific errors
+      console.log('Contract error:', errorMessage);
+    }
+  } else {
+    // Handle network or other errors
+    console.error('Network or system error:', error);
+  }
+}
+```
+
+## Conclusion
+
+CosmWasm contracts offer powerful capabilities that go beyond traditional EVM contracts. Their self-describing nature and flexible query system make them particularly well-suited for building robust and maintainable applications. By understanding and leveraging these features through the WASM precompile, you can create more sophisticated and user-friendly applications on the Sei network.

--- a/pages/build/dev-token-standards.mdx
+++ b/pages/build/dev-token-standards.mdx
@@ -61,7 +61,7 @@ the smart contract directly.
   are priorities or for native applications.
 
 Learn more about creating tokens using TokenFactory in the
-[TokenFactory Tutorial](/dev-tutorials/tokenfactory-tutorial).
+[TokenFactory Tutorial](build/tokenfactory-tutorial).
 
 ### Smart Contract Tokens
 
@@ -76,7 +76,7 @@ Learn more about creating tokens using TokenFactory in the
 - **Interoperability**: Both standards support pointer contracts, enabling
   seamless interaction between native and EVM environments.
 - **Interoperability and Pointer Contracts**:
-  [Pointer contracts](/dev-tutorials/pointer-contracts) enable interoperability
+  [Pointer contracts](build/pointers/pointer-contracts) enable interoperability
   between ERC20 and CW20 tokens, allowing for seamless interaction between the
   two standards. A registry is kept to track pointer contracts and facilitate
   interoperability.
@@ -88,7 +88,7 @@ Learn more about creating tokens using TokenFactory in the
    Regardless of the choice, both TokenFactory and CW20/ERC20 tokens can have pointer contracts deployed, facilitating seamless cross-vm interoperability.
 
 For more detailed guidance, refer to the
-[Pointer Contracts Documentation](/dev-tutorials/pointer-contracts).
+[Pointer Contracts Documentation](build/pointers/pointer-contracts).
 
 </Blockquote>
 

--- a/pages/build/evm-cli-tutorial.mdx
+++ b/pages/build/evm-cli-tutorial.mdx
@@ -1,14 +1,14 @@
 # Interact with EVM on Sei via CLI
 
 You can query or send transactions to Sei easily via CLI once you have the
-`seid` command installed (see [Installing Seid](./installing-seid))
+`seid` command installed (see [Installing Seid](node/getting-started))
 
 ## Queries
 
 If the machine you run these commands from are not running a node of the
 network, you'll need to append `--node http://url-to-sei-cosmos-rpc` to your
 command. Refer to the
-[Tools and Resources](../resources-tools-and-resources.mdx) page for a list of
+[Tools and Resources](providers/rpc-providers) page for a list of
 RPC endpoints.
 
 - `seid q evm sei-addr [some EVM address]`: Gets the associated Sei address of
@@ -32,7 +32,7 @@ Sending transactions via CLI requires you to have keys added via
 
 If the machine you run these commands from are not a node of the network, you'd
 need to append `--evm-rpc http://url-to-sei-evm-rpc` to your command. Refer to
-the [Tools and Resources](../resources-tools-and-resources.mdx) page for a list
+the [Tools and Resources](build/resources-tools-and-resources.mdx) page for a list
 of RPC endpoints.
 
 - `seid tx evm associate-address`: Associates the Sei address and EVM address

--- a/pages/build/nft-contract-tutorial.mdx
+++ b/pages/build/nft-contract-tutorial.mdx
@@ -186,7 +186,7 @@ address. This NFT contract is linked to the ERC721 NFT contract, meaning any
 activities involving CW721 NFTs will also reflect on the state of the ERC721
 NFTs and vice versa.
 
-<Callout type="info">Learn more about EVM interoperability and pointer contracts [here](../dev-advanced-concepts/interoperability/introduction.mdx).</Callout>
+<Callout type="info">Learn more about EVM interoperability and pointer contracts [here](build/pointers/overview).</Callout>
 
 </Tabs.Tab>
 <Tabs.Tab>
@@ -210,8 +210,6 @@ Before starting, ensure you have:
   contracts. Start with the [CosmWasm Book](https://book.cosmwasm.com/).
 - **Docker**: Required for using the CosmWasm Rust Optimizer tool. Install from
   [Docker's official website](https://docs.docker.com/engine/install/).
-
-<Callout type="info">You can obtain devnet tokens from one of the faucets listed [here](../dev-ecosystem-providers/faucets).</Callout>
 
 ## Setting Up Your Environment
 
@@ -335,7 +333,7 @@ address. This NFT contract is linked to the CW721 NFT contract, meaning any
 activities involving CW721 NFTs will also reflect on the state of the ERC721
 NFTs and vice versa.
 
-<Callout type="info">Learn more about EVM interoperability and pointer contracts [here](./pointer-contracts.mdx).</Callout>
+<Callout type="info">Learn more about EVM interoperability and pointer contracts [here](build/pointers/pointer-contracts).</Callout>
 
 </Tabs.Tab>
 </Tabs>

--- a/pages/build/pointers/pointer-contracts.mdx
+++ b/pages/build/pointers/pointer-contracts.mdx
@@ -1,7 +1,7 @@
 import { Callout } from 'nextra/components';
 
 <Callout type="info" emoji="ℹ️">
-  For an overview of Pointer Contracts click [here](bvuild/pointers/overview).
+  For an overview of Pointer Contracts click [here](build/pointers/overview).
 </Callout>
 
 ### Deploying Pointer Contracts

--- a/pages/build/pointers/pointer-contracts.mdx
+++ b/pages/build/pointers/pointer-contracts.mdx
@@ -1,7 +1,7 @@
 import { Callout } from 'nextra/components';
 
 <Callout type="info" emoji="ℹ️">
-  For an overview of Pointer Contracts click [here](/dev-interoperability/pointer-contracts).
+  For an overview of Pointer Contracts click [here](bvuild/pointers/overview).
 </Callout>
 
 ### Deploying Pointer Contracts
@@ -18,7 +18,7 @@ various token standards using the seid CLI tool.
 The list of requirements for deploying a pointer is fairly short:
 
 - Sei light client (CLI/daemon) installed on your machine. You can follow the
-  [installation guide](./installing-seid.mdx) if needed.
+  [installation guide](../../node/getting-started) if needed.
 - Address for the relevant contract (the "pointee")
 
 When a pointer is registered for any given contract, the two are mapped and

--- a/pages/build/pointers/pointer-tokenfactory.mdx
+++ b/pages/build/pointers/pointer-tokenfactory.mdx
@@ -2,7 +2,7 @@ import { Callout } from 'nextra/components';
 
 ### **First Steps**
 
-Refer to the [Tokenfactory tutorial](../tokenfactory-tutorial.mdx) for details
+Refer to the [Tokenfactory tutorial](build/tokenfactory-tutorial) for details
 on how to create a tokenfactory denom and an associated pointer contract.
 
 ## Create Pointer Contract

--- a/pages/build/resources-tools-and-resources.mdx
+++ b/pages/build/resources-tools-and-resources.mdx
@@ -35,7 +35,7 @@ RPC endpoints.
 
 ## Public Endpoints
 
-<Callout type="warning">Public RPC endpoints should only be used for development. For production apps, use a dedicated RPC endpoint or [set up your own RPC node](/running-a-sei-node).</Callout>
+<Callout type="warning">Public RPC endpoints should only be used for development. For production apps, use a [dedicated RPC endpoint](providers/rpc-providers), or [set up your own RPC node](node/getting-started).</Callout>
 
 Please visit our
 [chain registry](https://github.com/sei-protocol/chain-registry/blob/main/chains.json)

--- a/pages/build/seid-devtool.mdx
+++ b/pages/build/seid-devtool.mdx
@@ -52,7 +52,7 @@ seid tx evm register-evm-pointer NATIVE \
   factory/sei1ep3f207kt7julz9tjwxp2x8kluj0y9l6u0fume/gptw \
   --gas-fee-cap=100000000000 \
   --gas-limit=2500000 \
-  --evm-rpc=https://evm-rpc.sei.basementnodes.ca \
+  --evm-rpc=https://localhost:8545 \
   --from tf \
   --generate-only
 ```
@@ -67,7 +67,7 @@ inspect the transaction details:
 
 ```bash
 cast tx 0x5010e6600e67f04a9bc3d3b670a7c2de380b180713d9a014a5dbd76b7e2190f1 \
-  --rpc-url=https://evm-rpc.sei.basementnodes.ca
+  --rpc-url=https://localhost:8545
 ```
 
 This provides detailed transaction information:
@@ -151,7 +151,7 @@ seid tx gov submit-proposal param-change proposal.json \
 
 # EVM contract interaction
 seid tx evm send-tx \
-  --evm-rpc=https://evm-rpc.sei.basementnodes.ca \
+  --evm-rpc=http://localhost:8545 \
   --gas-limit=2500000 \
   --from=mykey \
   --generate-only > evm_template.json

--- a/pages/build/tokenfactory-allowlist.mdx
+++ b/pages/build/tokenfactory-allowlist.mdx
@@ -2,7 +2,7 @@ import { Callout } from 'nextra/components';
 
 # Token Allowlists
 
-The [Sei Token Factory module](/pages/dev-tutorials/tokenfactory-tutorial.mdx)
+The [Sei Token Factory module](build//tokenfactory-tutorial)
 enables token creators to restrict who can interact with their custom tokens
 through the use of allowlists.
 
@@ -18,8 +18,6 @@ To create a token on the devnet, ensure you have the following setup:
 - The `seid` CLI installed.
 - A wallet with SEI tokens on devnet.
 - Access to a running Sei blockchain node.
-
-<Callout type="info">You can obtain devnet tokens from one of the faucets listed [here](../dev-ecosystem-providers/faucets).</Callout>
 
 <details>
 <summary>Command Line Argument Overview</summary>
@@ -166,7 +164,7 @@ curl -X 'GET' \
 
 To enable usage of this token in EVM environments, you can create a pointer
 contract. The detailed process is outlined in the
-[<ins>Token Factory tutorial</ins>](tokenfactory-tutorial.mdx#create-pointer-contract).
+[<ins>Token Factory tutorial</ins>](build/tokenfactory-tutorial.mdx#create-pointer-contract).
 
 For more advanced features and in-depth information, refer to the
 [<ins>Token Factory module documentation</ins>](https://github.com/sei-protocol/sei-chain/tree/main/x/tokenfactory).

--- a/pages/build/tokenfactory-tutorial.mdx
+++ b/pages/build/tokenfactory-tutorial.mdx
@@ -167,7 +167,7 @@ version: 1
 This pointer contract allows EVM wallets and applications to interact directly
 with your TokenFactory token.
 
-<Callout type="info">Learn more about EVM interoperability and pointer contracts [here](../interoperability/overview.mdx).</Callout>
+<Callout type="info">Learn more about EVM interoperability and pointer contracts [here](build/pointers/overview.mdx).</Callout>
 
 ---
 

--- a/pages/learn/dev-chains.mdx
+++ b/pages/learn/dev-chains.mdx
@@ -55,7 +55,7 @@ control over all tokens and governance decisions.
 - **Purpose**: Development
 - **Chain ID**: Set by user (default: `sei-chain`)
 
-Please read the [Nodes Introduction](/dev-node/intro) section for more
+Please read the [Nodes Introduction](node/getting-started) section for more
 information on how to set up and run a local chain.
 
 ## Chain Registry

--- a/pages/learn/dev-gas.mdx
+++ b/pages/learn/dev-gas.mdx
@@ -29,7 +29,7 @@ completing the transaction.
 `Fee = Gas Price * Gas Limit`.
 
 To help developers and users estimate fees on Sei, please reference
-[Sei Gas](seigas.com) and the associated
+[Sei Gas](https://seigas.com) and the associated
 [APIs](https://docs.blocknative.com/gas-prediction/gas-platform) provided by
 Blocknative. Their estimates are based on real-time SEI data and advanced ML
 modeling to accurately and consistently estimate SEI transaction fees.

--- a/pages/learn/dev-interoperability.mdx
+++ b/pages/learn/dev-interoperability.mdx
@@ -24,7 +24,7 @@ environment. They provide a gateway for users and developers to access native
 Sei functionalities through the EVM RPC interface.
 
 For instructions on utilizing EVM precompiles, refer to the
-[Example Usage](./precompiles/example-usage.mdx) section.
+[Example Usage](reference/precompiles/example-usage.mdx) section.
 
 ## Pointer Contracts
 

--- a/pages/learn/general-staking.mdx
+++ b/pages/learn/general-staking.mdx
@@ -17,16 +17,14 @@ validator’s weight is based on the number of tokens delegated to them plus the
 own stake.
 
 The Sei protocol incentivizes validators and delegators with staking rewards
-from gas fees and inflation rewards. Fees and inflation rewards are distributed
-to validators and their delegators proportionally to their staked amount.
-Validators typically keep a portion of rewards as commission and distribute the
-rest to delegators. Users can view a validator’s commission rate on the Sei App
-or by querying the validator information on-chain.
+from gas fees and genesis token unlocks. ALl rewards are distributed
+to delegators proportional to their delegation, and the validator keeps a percentage of this as commission.
+Users can view a validator’s commission rate on the Sei App, or by querying the validator information on-chain.
 
 ## How to Stake
 
 Staking on Sei can be done through the Sei App, via the `seid` CLI, or even
-through REST or RPC calls.
+through API calls.
 
 - **Sei App**: [Staking](https://app.sei.io/stake)
 - **seid CLI**: `seid tx staking [command] [flags]`
@@ -77,14 +75,18 @@ this period, the tokens return to the delegator’s wallet and become available
 for transactions. Users can re-delegate to another validator instantly without
 waiting for the un-bonding period to end.
 
+### Jailing
+
+To ensure network uptime and overall security, validators must meet strict
+standards and consistently participate in the consensus process.
+Jailing can occur if these standards are not met. Jailed validators are excluded from
+participating consensus for a period and will not generate rewards during this time.
+
 ### Slashing
 
-Running a validator is a big responsibility. Validators must meet strict
-standards and constantly monitor and participate in the consensus process.
-Slashing is the penalty for misbehaving validators. When a validator gets
-slashed, they lose a portion of their stake as well as a portion of their
-delegator's stake. Slashed validators also get jailed, or excluded, from
-consensus for a period.
+When a validator is jailed, they may also be slashed.
+If slashing occurs, the network will burn a portion of total delegations for that validator,
+including their delegator's staked tokens.
 
 Slashing occurs under the following conditions:
 
@@ -93,30 +95,37 @@ Slashing occurs under the following conditions:
 - **Downtime**: Being unresponsive or unreachable for a period.
 - **Missed Votes**: Missing votes in consensus.
 
-Validators monitor each other and can submit evidence of misbehavior. Once
-discovered, the misbehaving validator will have a portion of their funds slashed
+Validators monitor each other and can submit evidence of misbehavior. If
+confirmed, the misbehaving validator will have a portion of their funds slashed
 and will be jailed.
+
+#### Parameters
+
+Slashing parameters are determined through governance and are network-enforced.
+They can be queried through the [slashing module](Thttps://rest.sei-apis.com/cosmos/slashing/v1beta1/params).
 
 ## Common Questions
 
 ### What happens if my validator gets slashed?
 
-If your validator gets slashed, a portion of both the validator’s and your
-staked tokens will be forfeited. This penalty encourages the selection of
-reliable validators and active monitoring of their performance.
+If your validator gets slashed, a portion of both the validator’s and your staked tokens will be forfeited. This penalty encourages the selection of reliable validators and active monitoring of their performance.
+
+For more details, see [Slashing](#slashing).
 
 ### Can I lose my staked tokens?
 
-Yes, if the validator you have staked with gets slashed for misbehavior, you
-will lose a portion of your staked tokens.
+If the validator you have staked with is jailed for inactivity or misbehavior, they may be slashed. You will lose a portion of your staked tokens.
+
+For more details, see [Jailing](#jailing) and [Slashing](#slashing).
 
 ### How are staking rewards calculated?
 
-Staking rewards are calculated based on the total amount of Sei staked and the
-validator’s performance. Rewards are distributed proportionally to the amount
-staked by each delegator.
+Staking rewards are calculated based on the total amount of Sei staked and the validator’s performance. Rewards are distributed proportionally to the amount staked by each delegator.
+
+For more details, see [Delegators](#delegators).
 
 ### Can I change my validator without un-bonding?
 
-Yes, you can use the re-delegation feature to move your stake from one validator
-to another without waiting for the un-bonding period to end.
+Yes, you can use the re-delegation feature to move your stake from one validator to another without waiting for the un-bonding period to end.
+
+For more details, see [Re-delegation](#re-delegation).

--- a/pages/learn/general-staking.mdx
+++ b/pages/learn/general-staking.mdx
@@ -102,7 +102,7 @@ and will be jailed.
 #### Parameters
 
 Slashing parameters are determined through governance and are network-enforced.
-They can be queried through the [slashing module](Thttps://rest.sei-apis.com/cosmos/slashing/v1beta1/params).
+They can be queried through the [slashing module](https://rest.sei-apis.com/cosmos/slashing/v1beta1/params).
 
 ## Common Questions
 

--- a/pages/node/_meta.json
+++ b/pages/node/_meta.json
@@ -5,20 +5,21 @@
 		"type": "separator",
 		"title": "Getting Started"
 	},
-	"getting-started": "Quick Start Guide",
-	"node-operators": "Node Operations Guide",
-	"reference": "Current Binary versions & Genesis Files",
+	"getting-started": "Quick Start",
+	"node-operators": "Node Setup and Operation",
+	"reference": "Current Binary Versions & Genesis Files",
+
+	"-- Validators": {
+		"type": "separator",
+		"title": "For Validators"
+	},
+	"validators": "Validator Setup and Operation",
+	"oracle-pricefeeder": "Oracle Price Feeder Operation",
 
 	"-- Advanced Operations": {
 		"type": "separator",
 		"title": "Advanced Operations"
 	},
 	"advanced-config-monitoring": "Advanced Configuration & Monitoring",
-	"technical-reference": "Technical Reference",
-
-	"-- Validators": {
-		"type": "separator",
-		"title": "Validators"
-	},
-	"validators": "Validator Operations Guide"
+	"technical-reference": "Technical Reference"
 }

--- a/pages/node/advanced-config-monitoring.mdx
+++ b/pages/node/advanced-config-monitoring.mdx
@@ -512,7 +512,7 @@ scrape_configs:
 ## Performance Testing
 
 <details>
-<summary>Example Benchmark Script using `eth_getLogs`</summary>
+<summary> Example Benchmark Script using `eth_getLogs` </summary>
 
 ```js
 import { ethers } from 'ethers';
@@ -664,6 +664,8 @@ async function testEthGetLogs() {
 // Run the test
 testEthGetLogs();
 ```
+
+</details>
 
 For specific customizations or additional metrics, consult the Sei
 technical communities in [Telegram](https://t.me/+ZN-NcvOWStQwMzk0) or

--- a/pages/node/advanced-config-monitoring.mdx
+++ b/pages/node/advanced-config-monitoring.mdx
@@ -1,4 +1,4 @@
-# Advanced Configuration and Monitoring Guide
+# Advanced Configuration and Monitoring
 
 This guide covers advanced configuration options and comprehensive monitoring
 setup for Sei nodes. We'll explore performance tuning, monitoring

--- a/pages/node/getting-started.mdx
+++ b/pages/node/getting-started.mdx
@@ -524,6 +524,6 @@ After your node is up and running, consider the following:
 
 Additional documentation is available in:
 
-- [Advanced Configuration & Monitoring Guide](./advanced-config-monitoring)
-- [Node Operations Guide](./node-operators)
-- [Validator Operations Guide](./validators)
+- [Advanced Configuration & Monitoring Guide](node/advanced-config-monitoring)
+- [Node Operations Guide](node/node-operators)
+- [Validator Operations Guide](node/validators)

--- a/pages/node/getting-started.mdx
+++ b/pages/node/getting-started.mdx
@@ -19,6 +19,7 @@ following minimum requirements:
 ### **Base System Setup**
 
 #### **1. Update and Upgrade System**
+
 Before installing any dependencies, ensure your system is up to date:
 
 ```bash
@@ -26,6 +27,7 @@ sudo apt update && sudo apt upgrade -y
 ```
 
 #### **2. Install Essential Packages**
+
 Install required system dependencies:
 
 ```bash
@@ -33,48 +35,52 @@ sudo apt install make gcc git jq chrony curl lz4 wget tar build-essential -y
 ```
 
 #### **3. Synchronize System Time**
+
 Ensure your system clock is synchronized to prevent issues with block verification, IBC transfers, and Tendermint-based chains.
 
 - **Set Timezone to UTC** (Recommended)
 
-  ```bash
-  sudo timedatectl set-timezone UTC
-  ```
+```bash
+sudo timedatectl set-timezone UTC
+```
 
 - **Enable and Start Chrony**
 
-  ```bash
-  sudo systemctl enable --now chronyd
-  ```
+```bash
+sudo systemctl enable --now chronyd
+```
 
-  If you're using **ntpd** instead:
+If you're using **ntpd** instead:
 
-  ```bash
-  sudo apt install ntp -y
-  sudo systemctl enable --now ntp
-  ```
+```bash
+sudo apt install ntp -y
+sudo systemctl enable --now ntp
+```
 
-  Verify time synchronization:
+Verify time synchronization:
 
-  ```bash
-  timedatectl
-  ```
+```bash
+timedatectl
+```
 
 ---
 
 ## **4. Install Go (Golang)**
 
 ### **Required Version: `Go 1.22.x`**
+
 - Cosmos SDK projects require **Go 1.22.x**.
 - **Do NOT use Go 1.23.x** (incompatible).
 - Older versions **may work** but are not recommended.
 
 #### **Check for Existing Go Installation**
+
 Run:
 
 ```bash
 go version
 ```
+
 If a version **lower than 1.21** or **equal to / higher than 1.23** is installed, remove it:
 
 ```bash
@@ -82,26 +88,27 @@ sudo rm -rf /usr/local/go
 ```
 
 #### **Download and Install Go 1.22.x**
-1. Download the latest **Go 1.22.x** release:
+
+- Download the latest **Go 1.22.x** release:
 
 ```bash
 wget https://go.dev/dl/go1.22.0.linux-amd64.tar.gz
 ```
 
-2. Extract and install:
+- Extract and install:
 
 ```bash
 sudo tar -C /usr/local -xzf go1.22.0.linux-amd64.tar.gz
 ```
 
-3. Add Go to your environment variables (for Bash or Zsh):
+- Add Go to your environment variables (for Bash or Zsh):
 
 ```bash
 echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc
 source ~/.bashrc
 ```
 
-4. Verify installation:
+- Verify installation:
 
 ```bash
 go version
@@ -109,7 +116,7 @@ go version
 
 Expected output:
 
-```
+```sh
 go version go1.22.0 linux/amd64
 ```
 
@@ -352,9 +359,9 @@ maintained in this JSON:
 
 - Remove Existing Data Directory
 
-  ```bash
-  mv ~/.sei/data ~/.sei/data_backup_$(date +%s)
-  ```
+```bash
+mv ~/.sei/data ~/.sei/data_backup_$(date +%s)
+```
 
 - Download and Extract the Snapshot: Follow the instructions from the linked
   markdown file or use a command similar to:
@@ -426,8 +433,7 @@ pending-ttl-duration = "3s"
 pending-ttl-num-blocks = 5
 ```
 
-> **Recommendation:** Adjust these parameters if you encounter performance or
-> resource issues.
+> **Notice:** Adjust these parameters if you encounter performance or resource issues.
 
 ---
 

--- a/pages/node/getting-started.mdx
+++ b/pages/node/getting-started.mdx
@@ -67,9 +67,8 @@ timedatectl
 
 ## **4. Install Go (Golang)**
 
-### **Required Version: `Go 1.22.x`**
+### **Suggested Version: `Go 1.22.x`**
 
-- Cosmos SDK projects require **Go 1.22.x**.
 - **Do NOT use Go 1.23.x** (incompatible).
 - Older versions **may work** but are not recommended.
 

--- a/pages/node/node-operators.mdx
+++ b/pages/node/node-operators.mdx
@@ -1,4 +1,4 @@
-# Sei Node Operations Guide
+# Sei Node Operations
 
 This guide covers the detailed operational aspects of running a Sei node,
 including configuration management, maintenance procedures, and best practices

--- a/pages/node/oracle-pricefeeder.mdx
+++ b/pages/node/oracle-pricefeeder.mdx
@@ -1,4 +1,4 @@
-# Sei Oracle Price Feeder Guide
+# Sei Oracle Price Feeder
 
 ## Overview
 
@@ -6,61 +6,72 @@ The Sei Oracle Price Feeder is a mandatory component for validators in networks 
 
 Failure to maintain an active price feeder results in validator jailing and slashing due to missing oracle votes. The system expects consistent vote broadcasts within each oracle vote period.
 
-### Key Responsibilities
+## Core Functionality
 
-- Fetch real-time market prices from supported providers
-- Aggregate and filter data using time-weighted or volume-weighted averages
-- Submit periodic pre-vote and vote messages to the Sei blockchain
-- Monitor feeder health to prevent downtime
+The price feeder relies on several key processes:
 
-## 1. Installation
+1. Price Data Collection
 
-### 1.1 Install the Price Feeder
+   - Queries multiple supported exchanges for real-time market data
+   - Processes raw price data through cleaning and aggregation pipelines
+   - Applies deviation thresholds to filter outliers
+
+2. Vote Construction and Submission
+
+   - Monitors on-chain oracle parameters for vote timing
+   - Creates and signs MsgAggregateExchangeRateVote messages
+   - Broadcasts transactions via configured endpoints
+
+3. Health Monitoring
+   - Exposes metrics and health check endpoints
+   - Integrates with external monitoring services
+   - Provides real-time price data access
+
+## Setup
+
+### Installing the Binary
 
 ```bash
 cd sei-chain
 make install-price-feeder
 ```
 
-This compiles the price-feeder binary, typically placed in /usr/local/bin/.
+This compiles and copies the price-feeder binary to /usr/local/bin/.
 
-### 1.2 Create a Dedicated Feeder Account
+### Account Configuration
 
-Using a separate feeder account prevents sequence errors from rapid transaction signing and reduces security risks to your validator key.
+Create and configure a dedicated feeder account to prevent sequence errors and enhance security:
 
 ```bash
+# Create feeder account
 seid keys add price-feeder-delegate
 export PRICE_FEEDER_DELEGATE_ADDR=$(seid keys show -a price-feeder-delegate)
-```
 
-### 1.3 Assign the Feeder to Your Validator
-
-```bash
+# Assign feeder to validator
 seid tx oracle set-feeder $PRICE_FEEDER_DELEGATE_ADDR --from <validator-wallet> \
     --fees 2000usei -b block -y --chain-id sei-chain
-```
 
-### 1.4 Fund the Feeder Account
-
-```bash
+# Fund feeder account
 seid tx bank send <validator-wallet> $PRICE_FEEDER_DELEGATE_ADDR 1000000usei \
     --fees=2000usei -b block -y
 ```
 
-### 1.5 Configure Automatic Signing
+### Automatic Signing
 
 ```bash
 export PRICE_FEEDER_PASS=<your_password>
 ```
 
-For systemd usage, add this environment variable to the [Service] section.
+For systemd services, add this environment variable to the [Service] section.
 
-## 2. Configuration
+## Configuration Details
 
-The price feeder operates through a single `config.toml` file. This configuration is adapted from the Umee Price Feeder for Sei's oracle module. Below is a complete configuration template with inline comments explaining each component, followed by detailed explanations of key sections:
+The price feeder uses a single TOML configuration file that defines all operational parameters. Let's examine each major component:
+
+<details>
+<summary>Complete Configuration Template</summary>
 
 ```toml
-# Basic configuration for gas and server settings
 gas_adjustment = 1.5
 gas_prices = "0.00125usei"
 enable_server = true
@@ -69,14 +80,12 @@ enable_voter = true
 [server]
 listen_addr = "0.0.0.0:7171"
 read_timeout = "20s"
-verbose_cors = true    # Enables detailed CORS logging
+verbose_cors = true
 write_timeout = "20s"
 
 [[deviation_thresholds]]
 base = "ETH"
 threshold = "2"
-
-# You can repeat the same block for BTC, USDC, SEI, etc.
 
 [[currency_pairs]]
 base = "ETH"
@@ -84,16 +93,14 @@ chain_denom = "ueth"
 providers = ["huobi", "crypto", "coinbase", "kraken", "okx"]
 quote = "USDT"
 
-# Currency pairs for BTC, USDC, ATOM, etc...
-
 [account]
-address = "FEEDER_ADDR"   # e.g. $PRICE_FEEDER_DELEGATE_ADDR
-chain_id = "CHAIN_ID"     # e.g. sei-testnet-2 or sei-mainnet-xyz
-validator = "VALIDATOR_ADDR" # e.g. seivaloper1...
+address = "FEEDER_ADDR"
+chain_id = "CHAIN_ID"
+validator = "VALIDATOR_ADDR"
 prefix = "sei"
 
 [keyring]
-backend = "os"    # Options: "os", "file", "test", "memory"
+backend = "os"
 dir = "/root/.sei"
 
 [rpc]
@@ -118,7 +125,6 @@ websocket = "stream.binance.com:9443"
 [[healthchecks]]
 url = "https://hc-ping.com/your-uuid"
 timeout = "5s"
-
 
 gas_adjustment = 1.5
 gas_prices = "0.00125usei"
@@ -174,98 +180,66 @@ url = "<https://hc-ping.com/your-uuid>"
 timeout = "5s"
 ```
 
-### Configuration Section Details
+</details>
 
-Each section of the configuration serves a specific purpose in the price feeder's operation. Let's examine each component in detail:
+### Configuration Section Explanations
 
-1. **Root Level Settings**
+1. Root Level Settings
 
-   - `gas_adjustment`: Multiplier for gas estimation to ensure transactions succeed. A value of 1.5 provides a 50% buffer above the estimated gas.
-   - `gas_prices`: Chain-specific gas price in the network's base denomination (usei).
-   - `enable_server`: When true, activates the HTTP server for health checks and metrics.
-   - `enable_voter`: Controls whether this instance participates in price voting.
+   - The gas_adjustment value of 1.5 provides a 50% buffer above estimated gas requirements
+   - gas_prices defines the fee denomination and amount
+   - enable_server activates the HTTP metrics endpoint
+   - enable_voter controls price voting participation
 
-2. **Server Configuration `[server]`**
+2. Server Configuration
 
-   - `listen_addr`: Specifies which network interface and port the metrics server uses. The default 0.0.0.0:7171 allows access from any network interface.
-   - `read_timeout` and `write_timeout`: Control how long the HTTP server waits for incoming requests and responses.
-   - `verbose_cors`: Enables detailed logging of Cross-Origin Resource Sharing requests, helpful for debugging API access issues.
+   - listen_addr determines the network interface and port for metrics
+   - Timeout settings control request handling durations
+   - verbose_cors enables detailed access logging
 
-3. **Deviation Thresholds `[[deviation_thresholds]]`**
+3. Price Data Settings
 
-   - These settings help prevent outlier prices from affecting the aggregate price.
-   - When a provider's price deviates more than the specified number of standard deviations from the median, it is excluded from calculations.
-   - You should configure thresholds for each asset you're tracking (BTC, ETH, USDC, etc.).
+   - deviation_thresholds prevent outlier prices from affecting aggregation
+   - currency_pairs define trading pairs, on-chain denominations, and data sources
+   - provider_endpoints specify exchange API connection details
 
-4. **Currency Pairs `[[currency_pairs]]`**
+4. Chain Integration
 
-   - Defines which assets to track and how to track them.
-   - `base` and `quote` together specify the trading pair (e.g., ETH/USDT).
-   - `chain_denom` maps the external asset to its on-chain representation (e.g., "ueth" for ETH).
-   - `providers` lists which exchanges to query for this pair. Using multiple providers increases reliability and accuracy.
+   - account settings link to your validator and network
+   - keyring configuration manages transaction signing
+   - rpc settings enable chain communication
 
-5. **Account Settings `[account]`**
+5. Monitoring
+   - telemetry enables Prometheus metric collection
+   - healthchecks integrate with external monitoring
+   - Both systems help prevent missed votes
 
-   - Contains the critical chain-specific information for your feeder.
-   - The `address` field must match your delegated feeder account.
-   - `validator` must be your validator's operator address (starting with seivaloper).
-   - `chain_id` must match the network you're connecting to.
+## Deployment
 
-6. **Keyring Configuration `[keyring]`**
+### Systemd Service Configuration
 
-   - Controls how the feeder accesses and manages keys.
-   - The `backend` choice affects security and convenience:
-     - "os" uses your operating system's secure storage
-     - "file" stores keys encrypted on disk
-     - "test" and "memory" are for testing only
-   - `dir` must point to where your keys are stored.
+<details>
+<summary>Example Systemd Service File</summary>
 
-7. **RPC Settings `[rpc]`**
-
-   - Configures how the feeder communicates with your Sei node.
-   - Both GRPC (`grpc_endpoint`) and Tendermint RPC (`tmrpc_endpoint`) connections are required.
-   - `rpc_timeout` should be tuned based on your network latency to the node.
-
-8. **Telemetry Options `[telemetry]`**
-
-   - Enables Prometheus-compatible metrics collection.
-   - The hostname and service label options help identify metrics from different feeders.
-   - `prometheus_retention` determines how long metrics are kept in memory.
-
-9. **Provider Endpoints `[[provider_endpoints]]`**
-
-   - Specifies how to connect to each exchange.
-   - Both REST and WebSocket endpoints are needed for complete price data.
-   - Configure each provider you listed in your currency pairs.
-
-10. **Healthchecks `[[healthchecks]]`**
-    - Optional but recommended for production deployments.
-    - Integrates with external monitoring services like healthchecks.io.
-    - The feeder pings the specified URL after successful price votes.
-    - Alerts you if the feeder stops submitting prices.
-
-## 3. Running the Price Feeder
-
-### 3.1 Systemd Service Configuration
-
-```bash
-sudo tee /etc/systemd/system/price-feeder.service << EOF
+```ini
 [Unit]
 Description=Sei Price Feeder
 After=network-online.target
 
 [Service]
-User=$USER
-Environment="PRICE_FEEDER_PASS=<your_password>"
-ExecStart=$(which price-feeder) /path/to/config.toml
-Restart=always
+User=root
+Type=simple
+Environment="PRICE_FEEDER_PASS=YOUR_KEYRING_PASSWORD"
+ExecStart=/usr/local/bin/price-feeder /root/price_feeder_config.toml
+Restart=on-failure
 RestartSec=3
 LimitNOFILE=6553500
 
 [Install]
 WantedBy=multi-user.target
-EOF
 ```
+
+</details>
 
 Enable and start the service:
 
@@ -275,34 +249,35 @@ sudo systemctl enable price-feeder
 sudo systemctl start price-feeder
 ```
 
-## 4. Monitoring & Troubleshooting
+## Monitoring and Maintenance
 
-### 4.1 Health Monitoring
+### Health Monitoring Endpoints
 
-The price feeder exposes several monitoring endpoints when enable_server = true:
+When enable_server = true, these endpoints become available:
 
-- Health check: `curl -s http://127.0.0.1:7171/healthz`
-- Current prices: `curl -s http://127.0.0.1:7171/prices`
-- Metrics: `curl -s http://127.0.0.1:7171/metrics`
+```bash
+# Health check
+curl -s http://127.0.0.1:7171/healthz
 
-### 4.2 Log Monitoring
+# Current prices
+curl -s http://127.0.0.1:7171/prices
+
+# Metrics
+curl -s http://127.0.0.1:7171/metrics
+```
+
+### Log Monitoring
+
+Monitor service logs:
 
 ```bash
 journalctl -fu price-feeder -o cat
 ```
 
-### 4.3 Validator Status
+### Prometheus Integration
 
-Check validator status and unjail if necessary:
-
-```bash
-seid query staking validator $(seid keys show -a <validator-wallet>)
-seid tx slashing unjail --from <validator-wallet> --chain-id sei-chain
-```
-
-### 4.4 Prometheus Integration
-
-Example alert rules for monitoring:
+<details>
+<summary>Example Alert Rules</summary>
 
 ```yaml
 groups:
@@ -314,22 +289,50 @@ groups:
           severity: critical
 ```
 
-## 5. Best Practices
+</details>
 
-- Use multiple price providers for redundancy and accurate price aggregation
-- Run the feeder on the same machine as the validator for minimal latency
-- Enable comprehensive monitoring with Prometheus metrics
-- Configure alerts for missing votes or delayed price updates
-- Maintain sufficient funds in the feeder account for transaction fees
-- Regular log monitoring for error detection
-- Implement automated restarts via systemd
+## Operational Best Practices
 
-## 6. Operational Checklist
+1. Redundancy and Accuracy
 
-- Create and fund dedicated price feeder account
-- Set feeder delegation for validator
-- Install and configure price feeder with optimal settings
-- Configure systemd service with appropriate restart policies
-- Enable monitoring and alerting systems
-- Verify active vote submissions
-- Monitor validator jailing status
+   - Configure multiple price providers for reliable data
+   - Set appropriate deviation thresholds
+   - Maintain sufficient transaction fees
+
+2. Performance Optimization
+
+   - Co-locate feeder with validator node
+   - Configure appropriate RPC timeouts
+   - Monitor system resource usage
+
+3. Monitoring and Recovery
+
+   - Implement comprehensive metrics collection
+   - Configure alerting for missed votes
+   - Maintain automated restart procedures
+
+4. Security Considerations
+   - Use dedicated feeder accounts
+   - Secure key storage configuration
+   - Regular security audits
+
+## Troubleshooting Guide
+
+### Common Issues
+
+1. Missing Votes
+
+   - Check feeder account balance
+   - Verify RPC connectivity
+   - Review log files for errors
+
+2. Price Deviations
+
+   - Examine provider data quality
+   - Review threshold configurations
+   - Check for market anomalies
+
+3. System Problems
+   - Monitor resource usage
+   - Verify network connectivity
+   - Check disk space and I/O

--- a/pages/node/oracle-pricefeeder.mdx
+++ b/pages/node/oracle-pricefeeder.mdx
@@ -1,0 +1,335 @@
+# Sei Oracle Price Feeder Guide
+
+## Overview
+
+The Sei Oracle Price Feeder is a mandatory component for validators in networks utilizing the Sei oracle module. It ensures accurate and timely exchange rate data submission by fetching real-time market prices, aggregating data across multiple providers, and submitting periodic on-chain votes following network specifications.
+
+Failure to maintain an active price feeder results in validator jailing and slashing due to missing oracle votes. The system expects consistent vote broadcasts within each oracle vote period.
+
+### Key Responsibilities
+
+- Fetch real-time market prices from supported providers
+- Aggregate and filter data using time-weighted or volume-weighted averages
+- Submit periodic pre-vote and vote messages to the Sei blockchain
+- Monitor feeder health to prevent downtime
+
+## 1. Installation
+
+### 1.1 Install the Price Feeder
+
+```bash
+cd sei-chain
+make install-price-feeder
+```
+
+This compiles the price-feeder binary, typically placed in /usr/local/bin/.
+
+### 1.2 Create a Dedicated Feeder Account
+
+Using a separate feeder account prevents sequence errors from rapid transaction signing and reduces security risks to your validator key.
+
+```bash
+seid keys add price-feeder-delegate
+export PRICE_FEEDER_DELEGATE_ADDR=$(seid keys show -a price-feeder-delegate)
+```
+
+### 1.3 Assign the Feeder to Your Validator
+
+```bash
+seid tx oracle set-feeder $PRICE_FEEDER_DELEGATE_ADDR --from <validator-wallet> \
+    --fees 2000usei -b block -y --chain-id sei-chain
+```
+
+### 1.4 Fund the Feeder Account
+
+```bash
+seid tx bank send <validator-wallet> $PRICE_FEEDER_DELEGATE_ADDR 1000000usei \
+    --fees=2000usei -b block -y
+```
+
+### 1.5 Configure Automatic Signing
+
+```bash
+export PRICE_FEEDER_PASS=<your_password>
+```
+
+For systemd usage, add this environment variable to the [Service] section.
+
+## 2. Configuration
+
+The price feeder operates through a single `config.toml` file. This configuration is adapted from the Umee Price Feeder for Sei's oracle module. Below is a complete configuration template with inline comments explaining each component, followed by detailed explanations of key sections:
+
+```toml
+# Basic configuration for gas and server settings
+gas_adjustment = 1.5
+gas_prices = "0.00125usei"
+enable_server = true
+enable_voter = true
+
+[server]
+listen_addr = "0.0.0.0:7171"
+read_timeout = "20s"
+verbose_cors = true    # Enables detailed CORS logging
+write_timeout = "20s"
+
+[[deviation_thresholds]]
+base = "ETH"
+threshold = "2"
+
+# You can repeat the same block for BTC, USDC, SEI, etc.
+
+[[currency_pairs]]
+base = "ETH"
+chain_denom = "ueth"
+providers = ["huobi", "crypto", "coinbase", "kraken", "okx"]
+quote = "USDT"
+
+# Currency pairs for BTC, USDC, ATOM, etc...
+
+[account]
+address = "FEEDER_ADDR"   # e.g. $PRICE_FEEDER_DELEGATE_ADDR
+chain_id = "CHAIN_ID"     # e.g. sei-testnet-2 or sei-mainnet-xyz
+validator = "VALIDATOR_ADDR" # e.g. seivaloper1...
+prefix = "sei"
+
+[keyring]
+backend = "os"    # Options: "os", "file", "test", "memory"
+dir = "/root/.sei"
+
+[rpc]
+grpc_endpoint = "localhost:9090"
+rpc_timeout = "100ms"
+tmrpc_endpoint = "http://localhost:26657"
+
+[telemetry]
+enable_hostname = true
+enable_hostname_label = true
+enable_service_label = true
+enabled = true
+global_labels = [["chain_id", "sei-chain"]]
+service_name = "price-feeder"
+prometheus_retention = 60
+
+[[provider_endpoints]]
+name = "binance"
+rest = "https://api1.binance.com"
+websocket = "stream.binance.com:9443"
+
+[[healthchecks]]
+url = "https://hc-ping.com/your-uuid"
+timeout = "5s"
+
+
+gas_adjustment = 1.5
+gas_prices = "0.00125usei"
+enable_server = true
+enable_voter = true
+provider_timeout = "500ms"
+
+[server]
+listen_addr = "0.0.0.0:7171"
+read_timeout = "20s"
+write_timeout = "20s"
+
+[[deviation_thresholds]]
+base = "ETH"
+threshold = "2"
+
+[[currency_pairs]]
+base = "ETH"
+chain_denom = "ueth"
+providers = ["binance", "kraken", "coinbase"]
+quote = "USDT"
+
+[account]
+address = "$PRICE_FEEDER_DELEGATE_ADDR"
+chain_id = "sei-chain"
+validator = "VALIDATOR_ADDR"
+prefix = "sei"
+
+[keyring]
+backend = "os"
+dir = "/root/.sei"
+
+[rpc]
+grpc_endpoint = "localhost:9090"
+rpc_timeout = "500ms"
+tmrpc_endpoint = "<http://localhost:26657>"
+
+[telemetry]
+enabled = true
+enable_hostname = true
+enable_service_label = true
+service_name = "price-feeder"
+global_labels = [["chain_id", "sei-chain"]]
+prometheus_retention = 120
+
+[[provider_endpoints]]
+name = "binance"
+rest = "<https://api1.binance.com>"
+websocket = "stream.binance.com:9443"
+
+[[healthchecks]]
+url = "<https://hc-ping.com/your-uuid>"
+timeout = "5s"
+```
+
+### Configuration Section Details
+
+Each section of the configuration serves a specific purpose in the price feeder's operation. Let's examine each component in detail:
+
+1. **Root Level Settings**
+
+   - `gas_adjustment`: Multiplier for gas estimation to ensure transactions succeed. A value of 1.5 provides a 50% buffer above the estimated gas.
+   - `gas_prices`: Chain-specific gas price in the network's base denomination (usei).
+   - `enable_server`: When true, activates the HTTP server for health checks and metrics.
+   - `enable_voter`: Controls whether this instance participates in price voting.
+
+2. **Server Configuration `[server]`**
+
+   - `listen_addr`: Specifies which network interface and port the metrics server uses. The default 0.0.0.0:7171 allows access from any network interface.
+   - `read_timeout` and `write_timeout`: Control how long the HTTP server waits for incoming requests and responses.
+   - `verbose_cors`: Enables detailed logging of Cross-Origin Resource Sharing requests, helpful for debugging API access issues.
+
+3. **Deviation Thresholds `[[deviation_thresholds]]`**
+
+   - These settings help prevent outlier prices from affecting the aggregate price.
+   - When a provider's price deviates more than the specified number of standard deviations from the median, it is excluded from calculations.
+   - You should configure thresholds for each asset you're tracking (BTC, ETH, USDC, etc.).
+
+4. **Currency Pairs `[[currency_pairs]]`**
+
+   - Defines which assets to track and how to track them.
+   - `base` and `quote` together specify the trading pair (e.g., ETH/USDT).
+   - `chain_denom` maps the external asset to its on-chain representation (e.g., "ueth" for ETH).
+   - `providers` lists which exchanges to query for this pair. Using multiple providers increases reliability and accuracy.
+
+5. **Account Settings `[account]`**
+
+   - Contains the critical chain-specific information for your feeder.
+   - The `address` field must match your delegated feeder account.
+   - `validator` must be your validator's operator address (starting with seivaloper).
+   - `chain_id` must match the network you're connecting to.
+
+6. **Keyring Configuration `[keyring]`**
+
+   - Controls how the feeder accesses and manages keys.
+   - The `backend` choice affects security and convenience:
+     - "os" uses your operating system's secure storage
+     - "file" stores keys encrypted on disk
+     - "test" and "memory" are for testing only
+   - `dir` must point to where your keys are stored.
+
+7. **RPC Settings `[rpc]`**
+
+   - Configures how the feeder communicates with your Sei node.
+   - Both GRPC (`grpc_endpoint`) and Tendermint RPC (`tmrpc_endpoint`) connections are required.
+   - `rpc_timeout` should be tuned based on your network latency to the node.
+
+8. **Telemetry Options `[telemetry]`**
+
+   - Enables Prometheus-compatible metrics collection.
+   - The hostname and service label options help identify metrics from different feeders.
+   - `prometheus_retention` determines how long metrics are kept in memory.
+
+9. **Provider Endpoints `[[provider_endpoints]]`**
+
+   - Specifies how to connect to each exchange.
+   - Both REST and WebSocket endpoints are needed for complete price data.
+   - Configure each provider you listed in your currency pairs.
+
+10. **Healthchecks `[[healthchecks]]`**
+    - Optional but recommended for production deployments.
+    - Integrates with external monitoring services like healthchecks.io.
+    - The feeder pings the specified URL after successful price votes.
+    - Alerts you if the feeder stops submitting prices.
+
+## 3. Running the Price Feeder
+
+### 3.1 Systemd Service Configuration
+
+```bash
+sudo tee /etc/systemd/system/price-feeder.service << EOF
+[Unit]
+Description=Sei Price Feeder
+After=network-online.target
+
+[Service]
+User=$USER
+Environment="PRICE_FEEDER_PASS=<your_password>"
+ExecStart=$(which price-feeder) /path/to/config.toml
+Restart=always
+RestartSec=3
+LimitNOFILE=6553500
+
+[Install]
+WantedBy=multi-user.target
+EOF
+```
+
+Enable and start the service:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable price-feeder
+sudo systemctl start price-feeder
+```
+
+## 4. Monitoring & Troubleshooting
+
+### 4.1 Health Monitoring
+
+The price feeder exposes several monitoring endpoints when enable_server = true:
+
+- Health check: `curl -s http://127.0.0.1:7171/healthz`
+- Current prices: `curl -s http://127.0.0.1:7171/prices`
+- Metrics: `curl -s http://127.0.0.1:7171/metrics`
+
+### 4.2 Log Monitoring
+
+```bash
+journalctl -fu price-feeder -o cat
+```
+
+### 4.3 Validator Status
+
+Check validator status and unjail if necessary:
+
+```bash
+seid query staking validator $(seid keys show -a <validator-wallet>)
+seid tx slashing unjail --from <validator-wallet> --chain-id sei-chain
+```
+
+### 4.4 Prometheus Integration
+
+Example alert rules for monitoring:
+
+```yaml
+groups:
+  - name: validator_alerts
+    rules:
+      - alert: OraclePriceFeedDelay
+        expr: time() - sei_oracle_price_timestamp > 300
+        labels:
+          severity: critical
+```
+
+## 5. Best Practices
+
+- Use multiple price providers for redundancy and accurate price aggregation
+- Run the feeder on the same machine as the validator for minimal latency
+- Enable comprehensive monitoring with Prometheus metrics
+- Configure alerts for missing votes or delayed price updates
+- Maintain sufficient funds in the feeder account for transaction fees
+- Regular log monitoring for error detection
+- Implement automated restarts via systemd
+
+## 6. Operational Checklist
+
+- Create and fund dedicated price feeder account
+- Set feeder delegation for validator
+- Install and configure price feeder with optimal settings
+- Configure systemd service with appropriate restart policies
+- Enable monitoring and alerting systems
+- Verify active vote submissions
+- Monitor validator jailing status

--- a/pages/node/oracle-pricefeeder.mdx
+++ b/pages/node/oracle-pricefeeder.mdx
@@ -94,8 +94,8 @@ providers = ["huobi", "crypto", "coinbase", "kraken", "okx"]
 quote = "USDT"
 
 [account]
-address = "FEEDER_ADDR"
-chain_id = "CHAIN_ID"
+address = "FEEDER_ADDR"   # e.g. $PRICE_FEEDER_DELEGATE_ADDR
+chain_id = "CHAIN_ID"     # e.g. sei-testnet-2 or sei-mainnet-xyz
 validator = "VALIDATOR_ADDR"
 prefix = "sei"
 

--- a/pages/node/technical-reference.mdx
+++ b/pages/node/technical-reference.mdx
@@ -1,4 +1,4 @@
-# Sei Technical Reference Guide
+# Sei Technical Reference
 
 This guide serves as a comprehensive reference for Sei node operators and
 validators, providing detailed command syntax, configuration parameters, and

--- a/pages/node/validators.mdx
+++ b/pages/node/validators.mdx
@@ -117,7 +117,7 @@ unconditional_peer_ids = "validator_node_id"
 
 Implement secure key backup procedures. Remember to choose the storage media carefully! Mechanical / flash based storage can fail unexpectedly, and cloud storage should **never** be used.
 
-By default, the wallet key files are stored in your `/.sei` directory root, and the signer/consensus key in `/config`. Not only the `priv_validator_key.json`, but the wallet `.info` and `.address` file should also be saved.
+By default, the wallet key files are stored in your `/.sei` directory root, and the signer/consensus key in `/.sei/config`. Not only the `priv_validator_key.json`, but the wallet `.info` and `.address` file should also be saved.
 
 Example script to encrypt backups of key files:
 
@@ -176,7 +176,7 @@ sudo systemctl start seid
 
 Create and maintain an emergency response plan for various scenarios:
 
-#### Consult with your fellow valiidators or a member of the Sei Labs or Foundation team directly for advice
+#### Consult with your fellow validators or a member of the Sei Labs or Foundation team directly for advice
 
 ## Governance Participation
 

--- a/pages/node/validators.mdx
+++ b/pages/node/validators.mdx
@@ -8,7 +8,7 @@ A validator in the Sei network serves several critical functions. As a validator
 
 - Participating in consensus by proposing and validating blocks
 - Maintaining high uptime and performance to avoid slashing
-- Running a price feeder to provide oracle data (refer to the [Oracle Price Feeder Guide](./oracle-pricefeeder) for complete setup instructions)
+- Running a price feeder to provide oracle data (refer to the [Oracle Price Feeder Guide](node/oracle-pricefeeder) for complete setup instructions)
 - Managing delegator relationships and maintaining transparent operations
 - Participating in governance and network upgrades
 
@@ -87,7 +87,7 @@ The commission parameters require strategic consideration:
 
 ## Monitoring and Alerting
 
-**Please refer to the [Advanced Operations](./advanced-config-monitoring) section for details around monitoring + alerting for your validator, price feeder and other nodes.**
+**Please refer to the [Advanced Operations](node/advanced-config-monitoring) section for details around monitoring + alerting for your validator, price feeder and other nodes.**
 
 ## Security Practices
 

--- a/pages/node/validators.mdx
+++ b/pages/node/validators.mdx
@@ -1,4 +1,4 @@
-# Validator Operations Guide
+# Validator Operations
 
 This comprehensive guide explains how to operate a Sei validator node. We'll
 cover the complete lifecycle of a validator, from initial setup through ongoing
@@ -97,29 +97,96 @@ The commission parameters deserve careful consideration:
 - `commission-max-rate`: An upper limit that can never be exceeded
 - `commission-max-change-rate`: Maximum daily commission change
 
-## Oracle Price Feeder Setup
+Below is an expanded explanation of the **Oracle Price Feeder** setup and operations. This covers everything from creating a dedicated price-feeder account, to configuring and running the price feeder, to how it fetches and votes on prices on-chain. This also includes notes on monitoring, recommended best practices, and more in-depth references to the underlying logic.
 
-As a Sei validator, you must run a price feeder to provide oracle data. This is
-crucial for network operations.
+---
 
-First, install the price feeder:
+## Overview
 
-```bash
-cd sei-chain
-make install-price-feeder
-```
+Running a price feeder is **required** when your validator is participating in a network that depends on oracle data (e.g. Sei). The price feeder is responsible for:
 
-Create a configuration file for your price feeder:
+1. **Fetching real-time exchange rates** for a set of assets from various centralized-exchange (CEX) or aggregator data sources (called "providers").
+2. **Aggregating and computing** a time-weighted or volume-weighted average price for each asset pair.
+3. **Submitting periodic on-chain votes** (pre-vote and vote messages, handled automatically) following the network’s oracle specifications.
+
+If the feeder does not consistently broadcast valid oracle votes, the validator will be **jailed** by the chain’s oracle module, incurring downtime and potential slashings.
+
+---
+
+## Dedicated Price-Feeder Account
+
+Although you _can_ use your main validator key for both validation and oracle feeding, it’s **highly recommended** that you create a **dedicated** “feeder delegate” account. The primary reasons:
+
+- **Safety**: Reduces risk of accidentally revealing or compromising your validator signing key.
+- **Reduced Account Sequence Errors**: The price feeder signs many transactions in rapid intervals, which can conflict with other transactions from your validator account and lead to sequence mismatches.
+
+### Steps
+
+1. **Create a new key** within your keyring:
+
+   ```bash
+   seid keys add price-feeder-delegate
+   ```
+
+   You can name it whatever you like, e.g. `price-feeder-delegate`. This will prompt you for a password (if using an `os` or `file` keyring), which you can set.
+
+2. **Set that new address as the validator’s “feeder address”:**
+
+   ```bash
+   export PRICE_FEEDER_DELEGATE_ADDR=<the address from the step above>
+
+   seid tx oracle set-feeder $PRICE_FEEDER_DELEGATE_ADDR --from <validator-wallet> \
+       --fees 2000usei -b block -y --chain-id <chain-id>
+   ```
+
+3. **Send a small amount of funds** to that new account so it can pay for fees:
+
+   ```bash
+   seid tx bank send <validator-wallet> $PRICE_FEEDER_DELEGATE_ADDR \
+       [AMOUNT]usei --fees=2000usei -b block -y
+   ```
+
+4. **Export** the keyring password so the price feeder can sign automatically:
+
+   ```bash
+   export PRICE_FEEDER_PASS=<enter your keyring password>
+   ```
+
+   If you don’t set this variable, the feeder will prompt for a password at startup. For systemd usage, you can place this environment variable in the `[Service]` section (see below).
+
+---
+
+## Installing the Price Feeder
+
+1. **Clone or download** the `sei-chain` repo:
+
+   ```bash
+   git clone https://github.com/sei-protocol/sei-chain.git
+   cd sei-chain
+   ```
+
+2. **Compile and install** the standalone feeder binary:
+
+   ```bash
+   make install-price-feeder
+   ```
+
+   This produces a `price-feeder` binary typically placed in your `$GOPATH/bin` (for Go-based systems) or `/usr/local/bin`. You can verify it with `which price-feeder`.
+
+---
+
+## Configuration
+
+The price feeder operates off a single `config.toml` file (referred to as `/path/to/price_feeder_config.toml` below). In Sei, this config is heavily influenced by the [Umee Price Feeder](https://github.com/umee-network/umee/tree/main/price-feeder) but adapted for Sei’s `oracle` module. A sample `config.toml` might look like:
 
 <details>
 <summary>Price Feeder Configuration</summary>
 
 ```toml
 gas_adjustment = 1.5
-gas_prices = "0.01usei"
+gas_prices = "0.00125usei"
 enable_server = true
 enable_voter = true
-provider_timeout = "500ms"
 
 [server]
 listen_addr = "0.0.0.0:7171"
@@ -127,78 +194,194 @@ read_timeout = "20s"
 verbose_cors = true
 write_timeout = "20s"
 
+[[deviation_thresholds]]
+base = "ETH"
+threshold = "2"
+
+# (You can repeat the same block for BTC, USDC, SEI, etc.)
+
+[[currency_pairs]]
+base = "ETH"
+chain_denom = "ueth"
+providers = ["huobi", "crypto", "coinbase", "kraken", "okx"]
+quote = "USDT"
+
+# (Currency pairs for BTC, USDC, ATOM, etc...)
+
+[account]
+address = "FEEDER_ADDR"   # e.g. $PRICE_FEEDER_DELEGATE_ADDR
+chain_id = "CHAIN_ID"     # e.g. sei-testnet-2 or sei-mainnet-xyz
+validator = "VALIDATOR_ADDR" # e.g. seivaloper1...
+prefix = "sei"
+
 [keyring]
-backend = "file"
-dir = "/home/sei/.sei"
+backend = "os"
+dir = "/root/.sei"
 
 [rpc]
 grpc_endpoint = "localhost:9090"
-rpc_timeout = "500ms"
+rpc_timeout = "100ms"
 tmrpc_endpoint = "http://localhost:26657"
 
 [telemetry]
 enable_hostname = true
 enable_hostname_label = true
 enable_service_label = true
-prometheus_retention = 120
+enabled = true
+global_labels = [["chain_id", "sei-chain"]]
 service_name = "price-feeder"
+prometheus_retention = 60
 
 [[provider_endpoints]]
 name = "binance"
 rest = "https://api1.binance.com"
 websocket = "stream.binance.com:9443"
+
+[[healthchecks]]
+url = "https://hc-ping.com/your-uuid"
+timeout = "5s"
 ```
 
 </details>
 
-Start the price feeder as a service:
+### Key Sections
 
-```bash
-sudo tee /etc/systemd/system/price-feeder.service << EOF
+1. **`[account]`**
+
+   - `address` corresponds to the feeder account’s Bech32 address, i.e. `$PRICE_FEEDER_DELEGATE_ADDR`.
+   - `chain_id` is the chain ID of the network you’re using (must match your `seid` config).
+   - `validator` is the **operator address** of your validator, e.g. `seivaloper1xyz...`.
+   - `prefix` sets the human-readable prefix for addresses (“sei”). This is needed so the code knows how to encode/decode Bech32 addresses for your network.
+
+2. **`[keyring]`**
+
+   - `backend` is typically “os”, “file”, “test”, “memory”, etc. If you used `seid keys add ...` in typical production mode, you likely have an `os` or `file` backend.
+   - `dir` points to the location of `.sei/keys` or wherever your keys are stored. This is typically `~/.sei` or `/root/.sei`.
+
+3. **`[rpc]`**
+
+   - `tmrpc_endpoint` points to your node’s RPC address, typically `http://localhost:26657`.
+   - `grpc_endpoint` points to your node’s GRPC address, typically `localhost:9090`.
+   - `rpc_timeout` is how long the feeder waits for an RPC response before timing out.
+
+4. **`[server]`** (optional if `enable_server = true`)
+
+   - `listen_addr` sets the local interface/port for the feeder’s **health** and **metrics** API endpoint (default `0.0.0.0:7171`).
+   - `write_timeout` and `read_timeout` set how long the feeder’s HTTP server will wait before timing out.
+
+5. **`[[currency_pairs]]`**
+
+   - Each block indicates a `base` (e.g. `ETH`) and a `quote` (e.g. `USDT`) pair, plus the **chain denoms** and **providers** used to fetch prices for that pair.
+   - The `chain_denom` is the way the on-chain oracle recognizes your base. For instance, if the chain internally uses `ueth` for Ether.
+   - **Providers** must be supported (Binance, Kraken, Crypto, etc.). If you list multiple providers, the feeder tries to fetch from each and then does time-/volume-weighted averaging, ignoring outliers that deviate too far from the mean.
+
+6. **`[[deviation_thresholds]]`**
+
+   - For each `base` (like “ETH”), you can set a tolerance threshold that helps the feeder ignore obviously incorrect data from any single provider. E.g. `threshold = "2"` means that if a provider’s price is 2 standard deviations away from the aggregated median, that data point is filtered.
+
+7. **Healthchecks** (optional)
+   - If you define a `[healthchecks]` block with a URL, the feeder will `GET` that endpoint each time it broadcasts a successful price vote. Helpful for pinging third-party services like [healthchecks.io](https://healthchecks.io) to alert you if the feeder fails.
+
+---
+
+## Running as a Systemd Service
+
+Running the price feeder under **systemd** is a best practice for servers, ensuring it auto-starts on reboot and restarts if it crashes. Below is a typical unit file at `/etc/systemd/system/price-feeder.service`:
+
+```ini
 [Unit]
 Description=Sei Price Feeder
 After=network-online.target
 
 [Service]
-User=$USER
-ExecStart=$(which price-feeder) /path/to/config.toml
-Restart=always
+User=root
+Type=simple
+# Pass your keyring password
+Environment="PRICE_FEEDER_PASS=YOUR_KEYRING_PASSWORD"
+ExecStart=/usr/local/bin/price-feeder /root/price_feeder_config.toml
+Restart=on-failure
 RestartSec=3
-LimitNOFILE=65535
+LimitNOFILE=6553500
 
 [Install]
 WantedBy=multi-user.target
 EOF
+```
 
+Refresh and start the service, and watch initial logs for any issues:
+
+```sh
 sudo systemctl daemon-reload
 sudo systemctl enable price-feeder
-sudo systemctl start price-feeder
+sudo systemctl start price-feeder && journalctl -fu price-feeder -o cat
 ```
 
-## Monitoring and Alerting
+---
 
-### Validator-Specific Metrics
+## High-level breakdown of the feeder process:
 
-Beyond basic node monitoring, validators should track additional metrics:
+1. **Initialization**:
+
+   - Reads your `config.toml`.
+   - Sets up the keyring with your feeder account.
+   - Connects to your node's RPC and gRPC.
+
+2. **Price Gathering**:
+
+   - For each configured `provider` (Binance, Kraken, etc.), queries the _latest market data_ (candles, tickers).
+   - Cleans and discards outlier data if it is more than `N` standard deviations away from the median (defined by `[[deviation_thresholds]]`).
+   - Aggregates each data point into a final volume- or time-weighted price.
+
+3. **Voting**:
+
+   - Checks the on-chain `oracleParams.VotePeriod` to see when it’s time to broadcast a new vote.
+   - Constructs a `MsgAggregateExchangeRateVote` message listing all the `[base -> chain_denom]` pairs with their computed prices.
+   - Signs and broadcasts the transaction via the gRPC and RPC endpoints.
+   - If multiple currencies share the same `quote`, the feeder automatically converts them to the standard the oracle module expects (usually USD or USDT).
+
+4. **Healthchecks** (optional):
+
+   - After each successful vote, the feeder can ping a user-defined `healthchecks` endpoint, letting external services know it’s live and functioning.
+
+5. **Telemetry & API** (if `enable_server = true`):
+   - Exposes Prometheus-compatible metrics at `/metrics` on the `listen_addr`.
+   - Exposes JSON endpoints for health (`/healthz`) and the current computed prices (`/prices`).
+
+If the price feeder does not send any votes for an extended period, the on-chain module will detect missing votes and jail your validator.
+
+---
+
+## Monitoring & Alerting
+
+### Built-In Telemetry
+
+If `[telemetry]` is enabled in `config.toml`, the price feeder exposes internal metrics (e.g. how long it took to fetch data, last block voted on, errors, etc.):
+
+- **Endpoint**: `<listen_addr>/api/v1/metrics` (e.g. `http://127.0.0.1:7171/api/v1/metrics`)
+- **Format**: By default, Prometheus text format. You can pass `?format=json` to get JSON metrics.
+
+### Price Feeder Health
+
+- **Health** endpoint: `<listen_addr>/api/v1/healthz` returns a simple JSON with `"Status":"available"` if running.
+
+### On-Chain Checks
+
+Aside from direct logs and systemd status, you can also:
 
 ```bash
-# Check validator status
-seid query staking validator $(seid keys show -a $VALIDATOR_KEY)
-
-# Monitor signing status
-seid query slashing signing-info $(seid tendermint show-validator)
-
-# Check current delegations
-seid query staking delegations-to $(seid keys show -a $VALIDATOR_KEY)
+# Check your validator’s on-chain status
+seid query staking validator $(seid keys show -a <validator-key>)
 ```
 
-### Alert Configuration
+If your validator becomes jailed, you will no longer be signing blocks or generating rewards or commission. You can check the status in the staking module"
 
-Set up critical alerts for validator operations. Here are essential Prometheus
-alert rules:
+```sh
+curl -s "http://localhost:1317/cosmos/staking/v1beta1/validators/
+```
 
-<details>
-<summary>Validator Alert Rules</summary>
+### Example Prometheus Rules
+
+For a more robust setup, integrate the node’s and feeder’s metrics with a Prometheus + Grafana stack. Set rules like:
 
 ```yaml
 groups:
@@ -226,7 +409,28 @@ groups:
           summary: 'Oracle price feed delayed'
 ```
 
-</details>
+This should ensure you are alerted if the oracle feeder stops updating, or worse.
+
+---
+
+## Best Practices & Tips
+
+- **Use Multiple Providers**: For each base asset, specify at least three different data providers. Price feeders try to ignore outliers. The more providers you have, the more resilient your feed is.
+- **Separate Feeder Account**: Always use a dedicated account for feeding to reduce the chance of sequence collisions and keep your validator key safe.
+- **Keep Service & Node on Same Host**: Minimize latency by running the feeder on the same machine as the node it queries (or a local network if that is not possible).
+- **Enable Telemetry & Alerting**: Integrate your metrics into Prometheus or a similar system. Oracle feed downtime is a critical event.
+
+## Final Checklist
+
+1. **Create & Fund Delegate Feeder Account**
+2. **Set Feeder Address** on-chain to your newly created delegate
+3. **Install** the `price-feeder` binary
+4. **Write** your `config.toml` with correct accounts, pairs, RPC endpoints, and providers
+5. **Configure** systemd (or your preferred process manager)
+6. **Enable Telemetry & Alerting** with your favorite stack
+7. **Monitor** logs, ensure votes are being broadcast every oracle vote period
+
+If set up correctly, your validator will remain healthy and will continually submit price votes, thus contributing to the on-chain oracle’s price data and staying out of jail.
 
 ## Security Practices
 

--- a/pages/node/validators.mdx
+++ b/pages/node/validators.mdx
@@ -373,11 +373,123 @@ Aside from direct logs and systemd status, you can also:
 seid query staking validator $(seid keys show -a <validator-key>)
 ```
 
-If your validator becomes jailed, you will no longer be signing blocks or generating rewards or commission. You can check the status in the staking module"
+If your validator becomes jailed, you will no longer be signing blocks or generating rewards or commission. You can check the status in the staking module:
 
 ```sh
-curl -s "http://localhost:1317/cosmos/staking/v1beta1/validators/
+curl -s "http://localhost:1317/cosmos/staking/v1beta1/validators/"
 ```
+
+#### Even Simpler Method Using `seid`
+
+For a straightforward jailed status check, you can use:
+
+```sh
+seid query staking validator <validator-address> -o json | jq '.jailed'
+```
+
+Example usage:
+
+```sh
+seid query staking validator seivaloper1j9644d7qyln8smd2t42jvymj0yhjw5qkmw9fms -o json | jq '.jailed'
+```
+
+#### Fetch Complete Validator Object
+
+For a more general query that retrieves the full validator object by moniker:
+
+```sh
+#!/bin/bash
+
+MONIKER="$1"
+API_URL="http//localhost:1317/cosmos/staking/v1beta1/validators?pagination.limit=500"
+
+echo "Querying validators from $API_URL..."
+
+VALIDATOR_DATA=$(curl -s "$API_URL" | jq -c --arg MONIKER "$MONIKER" '.validators[] | select(.description.moniker == $MONIKER)')
+
+if [[ -z "$VALIDATOR_DATA" ]]; then
+    echo "❌ No validator found with moniker: $MONIKER"
+    exit 1
+fi
+
+echo "Validator details:"
+echo "$VALIDATOR_DATA" | jq '.'
+```
+
+Example usage:
+
+```sh
+root@seid:~# ./scripts/get_validator.sh Figment
+Querying validators from http://localhost:1317/cosmos/staking/v1beta1/validators?pagination.limit=500...
+Validator details:
+{
+  "operator_address": "seivaloper1y82m5y3wevjneamzg0pmx87dzanyxzht0kepvn",
+  "consensus_pubkey": {
+    "@type": "/cosmos.crypto.ed25519.PubKey",
+    "key": "P3MLnMNN/76GwQiCDHiniyNhRJ2sMPvtKxmvS8l4MyI="
+  },
+  "jailed": false,
+  "status": "BOND_STATUS_BONDED",
+  "tokens": "275418312918540",
+  "delegator_shares": "275418312918540.000000000000000000",
+  "description": {
+    "moniker": "Figment",
+    "identity": "E5F274B870BDA01D",
+    "website": "https://figment.io",
+    "security_contact": "security@figment.io",
+    "details": "Figment Inc."
+  },
+  "unbonding_height": "61344000",
+  "unbonding_time": "2024-03-24T08:55:08.357009625Z",
+  "commission": {
+    "commission_rates": {
+      "rate": "0.050000000000000000",
+      "max_rate": "0.500000000000000000",
+      "max_change_rate": "0.100000000000000000"
+    },
+    "update_time": "2024-02-01T16:12:19.780060576Z"
+  },
+  "min_self_delegation": "1"
+}
+```
+
+Additionally, you can check a validator's status by moniker using the following script:
+
+```sh
+#!/bin/bash
+
+MONIKER="$1"
+API_URL="http://localhost:1317/cosmos/staking/v1beta1/validators?pagination.limit=500"
+
+echo "Querying validators from $API_URL..."
+
+# Fetch the validator list and check if the moniker exists
+VALIDATOR_DATA=$(curl -s "$API_URL" | jq -c --arg MONIKER "$MONIKER" '.validators[] | select(.description.moniker | contains($MONIKER))')
+
+if [[ -z "$VALIDATOR_DATA" ]]; then
+    echo "❌ No validator found with moniker: $MONIKER"
+    exit 1
+fi
+
+# Extract jailed status
+JAILED=$(echo "$VALIDATOR_DATA" | jq -r '.jailed')
+
+if [[ "$JAILED" == "true" ]]; then
+    echo "🚨 Your validator **IS JAILED**! Take action immediately."
+else
+    echo "✅ Your validator is NOT jailed."
+fi
+```
+
+Example usage:
+
+```sh
+root@seid:~# ./scripts/amijailed.sh Figment
+Querying validators from http://localhost:1317/cosmos/staking/v1beta1/validators?pagination.limit=500...
+✅ Your validator is NOT jailed.
+```
+
+
 
 ### Example Prometheus Rules
 

--- a/pages/node/validators.mdx
+++ b/pages/node/validators.mdx
@@ -1,18 +1,14 @@
-# Validator Operations
+# Validator Operations Guide
 
-This comprehensive guide explains how to operate a Sei validator node. We'll
-cover the complete lifecycle of a validator, from initial setup through ongoing
-operations and maintenance. Understanding these concepts is crucial for
-maintaining a reliable and secure validator operation.
+This document covers the complete lifecycle of a validator node, from initial setup through ongoing operations and maintenance. Understanding these concepts is crucial for maintaining a reliable and secure validator operation.
 
 ## Understanding Validator Responsibilities
 
-A validator in the Sei network serves several critical functions. As a
-validator, you are responsible for:
+A validator in the Sei network serves several critical functions. As a validator, you are responsible for:
 
 - Participating in consensus by proposing and validating blocks
 - Maintaining high uptime and performance to avoid slashing
-- Providing accurate oracle price feeds for asset pricing
+- Running a price feeder to provide oracle data (refer to the [Oracle Price Feeder Guide](./oracle-pricefeeder) for complete setup instructions)
 - Managing delegator relationships and maintaining transparent operations
 - Participating in governance and network upgrades
 
@@ -20,8 +16,7 @@ validator, you are responsible for:
 
 ### Key Management
 
-The security of your validator begins with proper key management. Your validator
-requires several distinct keys:
+The security of your validator begins with proper key management. Your validator requires several distinct keys:
 
 ```bash
 # Validator consensus key - Used for signing blocks
@@ -29,19 +24,13 @@ seid tendermint show-validator
 
 # Operator key - Used for managing validator operations
 seid keys add operator
-
-# Oracle key - Used for price feed submissions
-seid keys add oracle
 ```
 
-These keys serve different purposes and should be managed with appropriate
-security measures. The consensus key, stored in `priv_validator_key.json`, is
-particularly critical as it's used to sign blocks.
+These keys serve different purposes and should be managed with appropriate security measures. The consensus key, stored in `priv_validator_key.json`, is particularly critical as it's used to sign blocks and could result in slashing if compromised or mishandled.
 
 ### Hardware Security Module (HSM) Integration
 
-For production validators, using an HSM is strongly recommended. Here's how to
-configure an HSM with your validator:
+For production validators, using an HSM is strongly recommended to protect your consensus key. Here's how to configure an HSM with your validator:
 
 <details>
 <summary>HSM Configuration Steps</summary>
@@ -72,8 +61,7 @@ EOF
 
 ### Validator Registration
 
-Before registering your validator, ensure your node is fully synced with the
-network. Then create your validator:
+Before registering your validator, ensure your node is fully synced with the network. The creation of a validator is a crucial step that requires careful consideration of commission parameters:
 
 ```bash
 seid tx staking create-validator \
@@ -91,297 +79,35 @@ seid tx staking create-validator \
     --from=operator
 ```
 
-The commission parameters deserve careful consideration:
+The commission parameters require strategic consideration:
 
-- `commission-rate`: Your initial commission rate
-- `commission-max-rate`: An upper limit that can never be exceeded
-- `commission-max-change-rate`: Maximum daily commission change
+- `commission-rate`: Your initial commission rate, which should be competitive while ensuring operational sustainability
+- `commission-max-rate`: An upper limit that can never be exceeded, setting a permanent cap on your commission
+- `commission-max-change-rate`: Maximum daily commission change, limiting how quickly you can adjust rates
 
-Below is an expanded explanation of the **Oracle Price Feeder** setup and operations. This covers everything from creating a dedicated price-feeder account, to configuring and running the price feeder, to how it fetches and votes on prices on-chain. This also includes notes on monitoring, recommended best practices, and more in-depth references to the underlying logic.
+## Monitoring and Alerting
 
----
+### Validator-Specific Metrics
 
-## Overview
-
-Running a price feeder is **required** when your validator is participating in a network that depends on oracle data (e.g. Sei). The price feeder is responsible for:
-
-1. **Fetching real-time exchange rates** for a set of assets from various centralized-exchange (CEX) or aggregator data sources (called "providers").
-2. **Aggregating and computing** a time-weighted or volume-weighted average price for each asset pair.
-3. **Submitting periodic on-chain votes** (pre-vote and vote messages, handled automatically) following the network’s oracle specifications.
-
-If the feeder does not consistently broadcast valid oracle votes, the validator will be **jailed** by the chain’s oracle module, incurring downtime and potential slashings.
-
----
-
-## Dedicated Price-Feeder Account
-
-Although you _can_ use your main validator key for both validation and oracle feeding, it’s **highly recommended** that you create a **dedicated** “feeder delegate” account. The primary reasons:
-
-- **Safety**: Reduces risk of accidentally revealing or compromising your validator signing key.
-- **Reduced Account Sequence Errors**: The price feeder signs many transactions in rapid intervals, which can conflict with other transactions from your validator account and lead to sequence mismatches.
-
-### Steps
-
-1. **Create a new key** within your keyring:
-
-   ```bash
-   seid keys add price-feeder-delegate
-   ```
-
-   You can name it whatever you like, e.g. `price-feeder-delegate`. This will prompt you for a password (if using an `os` or `file` keyring), which you can set.
-
-2. **Set that new address as the validator’s “feeder address”:**
-
-   ```bash
-   export PRICE_FEEDER_DELEGATE_ADDR=<the address from the step above>
-
-   seid tx oracle set-feeder $PRICE_FEEDER_DELEGATE_ADDR --from <validator-wallet> \
-       --fees 2000usei -b block -y --chain-id <chain-id>
-   ```
-
-3. **Send a small amount of funds** to that new account so it can pay for fees:
-
-   ```bash
-   seid tx bank send <validator-wallet> $PRICE_FEEDER_DELEGATE_ADDR \
-       [AMOUNT]usei --fees=2000usei -b block -y
-   ```
-
-4. **Export** the keyring password so the price feeder can sign automatically:
-
-   ```bash
-   export PRICE_FEEDER_PASS=<enter your keyring password>
-   ```
-
-   If you don’t set this variable, the feeder will prompt for a password at startup. For systemd usage, you can place this environment variable in the `[Service]` section (see below).
-
----
-
-## Installing the Price Feeder
-
-1. **Clone or download** the `sei-chain` repo:
-
-   ```bash
-   git clone https://github.com/sei-protocol/sei-chain.git
-   cd sei-chain
-   ```
-
-2. **Compile and install** the standalone feeder binary:
-
-   ```bash
-   make install-price-feeder
-   ```
-
-   This produces a `price-feeder` binary typically placed in your `$GOPATH/bin` (for Go-based systems) or `/usr/local/bin`. You can verify it with `which price-feeder`.
-
----
-
-## Configuration
-
-The price feeder operates off a single `config.toml` file (referred to as `/path/to/price_feeder_config.toml` below). In Sei, this config is heavily influenced by the [Umee Price Feeder](https://github.com/umee-network/umee/tree/main/price-feeder) but adapted for Sei’s `oracle` module. A sample `config.toml` might look like:
-
-<details>
-<summary>Price Feeder Configuration</summary>
-
-```toml
-gas_adjustment = 1.5
-gas_prices = "0.00125usei"
-enable_server = true
-enable_voter = true
-
-[server]
-listen_addr = "0.0.0.0:7171"
-read_timeout = "20s"
-verbose_cors = true
-write_timeout = "20s"
-
-[[deviation_thresholds]]
-base = "ETH"
-threshold = "2"
-
-# (You can repeat the same block for BTC, USDC, SEI, etc.)
-
-[[currency_pairs]]
-base = "ETH"
-chain_denom = "ueth"
-providers = ["huobi", "crypto", "coinbase", "kraken", "okx"]
-quote = "USDT"
-
-# (Currency pairs for BTC, USDC, ATOM, etc...)
-
-[account]
-address = "FEEDER_ADDR"   # e.g. $PRICE_FEEDER_DELEGATE_ADDR
-chain_id = "CHAIN_ID"     # e.g. sei-testnet-2 or sei-mainnet-xyz
-validator = "VALIDATOR_ADDR" # e.g. seivaloper1...
-prefix = "sei"
-
-[keyring]
-backend = "os"
-dir = "/root/.sei"
-
-[rpc]
-grpc_endpoint = "localhost:9090"
-rpc_timeout = "100ms"
-tmrpc_endpoint = "http://localhost:26657"
-
-[telemetry]
-enable_hostname = true
-enable_hostname_label = true
-enable_service_label = true
-enabled = true
-global_labels = [["chain_id", "sei-chain"]]
-service_name = "price-feeder"
-prometheus_retention = 60
-
-[[provider_endpoints]]
-name = "binance"
-rest = "https://api1.binance.com"
-websocket = "stream.binance.com:9443"
-
-[[healthchecks]]
-url = "https://hc-ping.com/your-uuid"
-timeout = "5s"
-```
-
-</details>
-
-### Key Sections
-
-1. **`[account]`**
-
-   - `address` corresponds to the feeder account’s Bech32 address, i.e. `$PRICE_FEEDER_DELEGATE_ADDR`.
-   - `chain_id` is the chain ID of the network you’re using (must match your `seid` config).
-   - `validator` is the **operator address** of your validator, e.g. `seivaloper1xyz...`.
-   - `prefix` sets the human-readable prefix for addresses (“sei”). This is needed so the code knows how to encode/decode Bech32 addresses for your network.
-
-2. **`[keyring]`**
-
-   - `backend` is typically “os”, “file”, “test”, “memory”, etc. If you used `seid keys add ...` in typical production mode, you likely have an `os` or `file` backend.
-   - `dir` points to the location of `.sei/keys` or wherever your keys are stored. This is typically `~/.sei` or `/root/.sei`.
-
-3. **`[rpc]`**
-
-   - `tmrpc_endpoint` points to your node’s RPC address, typically `http://localhost:26657`.
-   - `grpc_endpoint` points to your node’s GRPC address, typically `localhost:9090`.
-   - `rpc_timeout` is how long the feeder waits for an RPC response before timing out.
-
-4. **`[server]`** (optional if `enable_server = true`)
-
-   - `listen_addr` sets the local interface/port for the feeder’s **health** and **metrics** API endpoint (default `0.0.0.0:7171`).
-   - `write_timeout` and `read_timeout` set how long the feeder’s HTTP server will wait before timing out.
-
-5. **`[[currency_pairs]]`**
-
-   - Each block indicates a `base` (e.g. `ETH`) and a `quote` (e.g. `USDT`) pair, plus the **chain denoms** and **providers** used to fetch prices for that pair.
-   - The `chain_denom` is the way the on-chain oracle recognizes your base. For instance, if the chain internally uses `ueth` for Ether.
-   - **Providers** must be supported (Binance, Kraken, Crypto, etc.). If you list multiple providers, the feeder tries to fetch from each and then does time-/volume-weighted averaging, ignoring outliers that deviate too far from the mean.
-
-6. **`[[deviation_thresholds]]`**
-
-   - For each `base` (like “ETH”), you can set a tolerance threshold that helps the feeder ignore obviously incorrect data from any single provider. E.g. `threshold = "2"` means that if a provider’s price is 2 standard deviations away from the aggregated median, that data point is filtered.
-
-7. **Healthchecks** (optional)
-   - If you define a `[healthchecks]` block with a URL, the feeder will `GET` that endpoint each time it broadcasts a successful price vote. Helpful for pinging third-party services like [healthchecks.io](https://healthchecks.io) to alert you if the feeder fails.
-
----
-
-## Running as a Systemd Service
-
-Running the price feeder under **systemd** is a best practice for servers, ensuring it auto-starts on reboot and restarts if it crashes. Below is a typical unit file at `/etc/systemd/system/price-feeder.service`:
-
-```ini
-[Unit]
-Description=Sei Price Feeder
-After=network-online.target
-
-[Service]
-User=root
-Type=simple
-# Pass your keyring password
-Environment="PRICE_FEEDER_PASS=YOUR_KEYRING_PASSWORD"
-ExecStart=/usr/local/bin/price-feeder /root/price_feeder_config.toml
-Restart=on-failure
-RestartSec=3
-LimitNOFILE=6553500
-
-[Install]
-WantedBy=multi-user.target
-EOF
-```
-
-Refresh and start the service, and watch initial logs for any issues:
-
-```sh
-sudo systemctl daemon-reload
-sudo systemctl enable price-feeder
-sudo systemctl start price-feeder && journalctl -fu price-feeder -o cat
-```
-
----
-
-## High-level breakdown of the feeder process:
-
-1. **Initialization**:
-
-   - Reads your `config.toml`.
-   - Sets up the keyring with your feeder account.
-   - Connects to your node's RPC and gRPC.
-
-2. **Price Gathering**:
-
-   - For each configured `provider` (Binance, Kraken, etc.), queries the _latest market data_ (candles, tickers).
-   - Cleans and discards outlier data if it is more than `N` standard deviations away from the median (defined by `[[deviation_thresholds]]`).
-   - Aggregates each data point into a final volume- or time-weighted price.
-
-3. **Voting**:
-
-   - Checks the on-chain `oracleParams.VotePeriod` to see when it’s time to broadcast a new vote.
-   - Constructs a `MsgAggregateExchangeRateVote` message listing all the `[base -> chain_denom]` pairs with their computed prices.
-   - Signs and broadcasts the transaction via the gRPC and RPC endpoints.
-   - If multiple currencies share the same `quote`, the feeder automatically converts them to the standard the oracle module expects (usually USD or USDT).
-
-4. **Healthchecks** (optional):
-
-   - After each successful vote, the feeder can ping a user-defined `healthchecks` endpoint, letting external services know it’s live and functioning.
-
-5. **Telemetry & API** (if `enable_server = true`):
-   - Exposes Prometheus-compatible metrics at `/metrics` on the `listen_addr`.
-   - Exposes JSON endpoints for health (`/healthz`) and the current computed prices (`/prices`).
-
-If the price feeder does not send any votes for an extended period, the on-chain module will detect missing votes and jail your validator.
-
----
-
-## Monitoring & Alerting
-
-### Built-In Telemetry
-
-If `[telemetry]` is enabled in `config.toml`, the price feeder exposes internal metrics (e.g. how long it took to fetch data, last block voted on, errors, etc.):
-
-- **Endpoint**: `<listen_addr>/api/v1/metrics` (e.g. `http://127.0.0.1:7171/api/v1/metrics`)
-- **Format**: By default, Prometheus text format. You can pass `?format=json` to get JSON metrics.
-
-### Price Feeder Health
-
-- **Health** endpoint: `<listen_addr>/api/v1/healthz` returns a simple JSON with `"Status":"available"` if running.
-
-### On-Chain Checks
-
-Aside from direct logs and systemd status, you can also:
+Beyond basic node monitoring, validators should track these critical metrics:
 
 ```bash
-# Check your validator’s on-chain status
-seid query staking validator $(seid keys show -a <validator-key>)
+# Check validator status
+seid query staking validator $(seid keys show -a $VALIDATOR_KEY)
+
+# Monitor signing status
+seid query slashing signing-info $(seid tendermint show-validator)
+
+# Check current delegations
+seid query staking delegations-to $(seid keys show -a $VALIDATOR_KEY)
 ```
 
-If your validator becomes jailed, you will no longer be signing blocks or generating rewards or commission. You can check the status in the staking module"
+### Alert Configuration
 
-```sh
-curl -s "http://localhost:1317/cosmos/staking/v1beta1/validators/
-```
+Set up critical alerts for validator operations. Here are essential Prometheus alert rules:
 
-### Example Prometheus Rules
-
-For a more robust setup, integrate the node’s and feeder’s metrics with a Prometheus + Grafana stack. Set rules like:
+<details>
+<summary>Validator Alert Rules</summary>
 
 ```yaml
 groups:
@@ -401,42 +127,22 @@ groups:
         annotations:
           summary: 'Validator has been jailed'
 
-      - alert: OraclePriceFeedDelay
-        expr: time() - sei_oracle_price_timestamp > 300
+      - alert: ConsensusStalled
+        expr: tendermint_consensus_height_status == 0
+        for: 5m
         labels:
           severity: critical
         annotations:
-          summary: 'Oracle price feed delayed'
+          summary: 'Consensus has stalled'
 ```
 
-This should ensure you are alerted if the oracle feeder stops updating, or worse.
-
----
-
-## Best Practices & Tips
-
-- **Use Multiple Providers**: For each base asset, specify at least three different data providers. Price feeders try to ignore outliers. The more providers you have, the more resilient your feed is.
-- **Separate Feeder Account**: Always use a dedicated account for feeding to reduce the chance of sequence collisions and keep your validator key safe.
-- **Keep Service & Node on Same Host**: Minimize latency by running the feeder on the same machine as the node it queries (or a local network if that is not possible).
-- **Enable Telemetry & Alerting**: Integrate your metrics into Prometheus or a similar system. Oracle feed downtime is a critical event.
-
-## Final Checklist
-
-1. **Create & Fund Delegate Feeder Account**
-2. **Set Feeder Address** on-chain to your newly created delegate
-3. **Install** the `price-feeder` binary
-4. **Write** your `config.toml` with correct accounts, pairs, RPC endpoints, and providers
-5. **Configure** systemd (or your preferred process manager)
-6. **Enable Telemetry & Alerting** with your favorite stack
-7. **Monitor** logs, ensure votes are being broadcast every oracle vote period
-
-If set up correctly, your validator will remain healthy and will continually submit price votes, thus contributing to the on-chain oracle’s price data and staying out of jail.
+</details>
 
 ## Security Practices
 
 ### Network Security
 
-Implement a sentry node architecture to protect your validator:
+Validators may choose to implement a sentry node architecture to protect the block signing node (the validator). This setup helps prevent DDoS attacks on your validator node by creating a layer of defensive proxies:
 
 ```bash
 # Validator node config.toml
@@ -449,13 +155,20 @@ addr_book_strict = false
 # Sentry node config.toml
 [p2p]
 pex = true
+persistent_peers = "validator_node_id@ip:port"
 private_peer_ids = "validator_node_id"
 addr_book_strict = true
+#optionsl
+unconditional_peer_ids = "validator_node_id"
 ```
 
 ### Key Management Practices
 
-Implement secure key backup procedures:
+Implement secure key backup procedures. Remember to choose the storage media carefully! Mechanical / flash based storage can fail unexpectedly, and cloud storage should **never** be used.
+
+By default, the wallet key files are stored in your `/.sei` directory root, and the signer/consensus key in `/config`. Not only the `priv_validator_key.json`, but the wallet `.info` and `.address` file should also be saved.
+
+Example script to encrypt backups of key files:
 
 <details>
 <summary>Key Backup Script</summary>
@@ -486,59 +199,42 @@ sha256sum $BACKUP_DIR/*.gpg > $BACKUP_DIR/checksums_$DATE.txt
 
 ### Planned Maintenance
 
-When performing planned maintenance:
+When performing planned maintenance, to minimize potential impact:
+
+- Notify delegators (recommended at least 24h in advance)
+
+Consider posting to:
+
+- Shared development team/validators comms channels
+- Social media channels
+- Validator website
+
+Don't forget to stop the service!
 
 ```bash
-# Notify delegators (recommended at least 24h in advance)
-# Consider posting to:
-# - Chain governance forum
-# - Social media channels
-# - Validator website
-
-# Gracefully stop the validator
+# Gracefully stop the node
 sudo systemctl stop seid
 
 # Perform maintenance tasks
 
 # Restart services
 sudo systemctl start seid
-sudo systemctl start price-feeder
 ```
 
 ### Emergency Procedures
 
-Create an emergency response plan:
+Create and maintain an emergency response plan for various scenarios:
 
-<details>
-<summary>Emergency Response Procedures</summary>
-
-```bash
-# 1. If double-signing is detected:
-sudo systemctl stop seid
-# Investigate priv_validator_state.json
-# Contact team and delegators
-
-# 2. If node is stuck:
-seid status
-# Check for consensus failures
-journalctl -u seid -n 100
-# Attempt safe restart
-sudo systemctl restart seid
-
-# 3. If oracle feed fails:
-systemctl status price-feeder
-# Check price-feeder logs
-journalctl -u price-feeder -n 100
-# Restart if necessary
-sudo systemctl restart price-feeder
-```
-
-</details>
+#### Consult with your fellow valiidators or a member of the Sei Labs or Foundation team directly for advice
 
 ## Governance Participation
 
-As a validator, you have a responsibility to participate in governance. Monitor
-and vote on proposals:
+As a validator, active participation in governance is required. Governance is the primary tool with which adjustments t0 various chain parameters are made.
+Another critical role for validators is to review, and ultimately approve or reject proposed software upgrades to the network.
+
+Governance proposals may be submitted by anyone willing to provide the mandatory (refundable) deposit, and can be voted on by any network user. Only votes by accounts delegating $SEI at the end of the voting period for a given proposal will be given weight.
+
+Proposals currently on chain can be queried at any given time:
 
 ```bash
 # List active proposals
@@ -554,22 +250,109 @@ seid tx gov vote 1 yes \
 
 ## Validator Economics
 
-Understanding validator economics is crucial for long-term success:
+Understanding validator economics is crucial for long-term success. Consider these key aspects:
 
-- Commission Rate Strategy: Set competitive rates while ensuring operational
-  sustainability
-- Delegation Management: Maintain good delegator relationships through
-  transparent communication
-- Reward Distribution: Rewards are distributed in real-time as blocks are
-  produced
-- Slashing Risks: Understand and mitigate risks of slashing through proper
-  operation
+- Commission Rate Strategy: Set competitive rates while ensuring operational sustainability
+- Delegation Management: Maintain good delegator relationships through transparent communication
+- Reward Distribution: Rewards are distributed in real-time as blocks are produced
+- Slashing Risks: Understand and mitigate risks of slashing through proper operation
+- Economic Security: Maintain adequate self-bonding to align incentives with delegators
+
+## Node Debugging and Logging
+
+### Debugging Procedures
+
+When encountering node issues, proper debugging information is crucial for resolution. Different types of issues require different debugging approaches:
+
+#### AppHash Mismatch Errors
+
+If you encounter an AppHash mismatch, you'll need to capture the state for comparison with a known good version:
+
+```bash
+# For SeiDB (most non-archive nodes):
+git clone https://github.com/sei-protocol/sei-db.git
+cd sei-db/tools
+make install
+systemctl stop seid
+seidb dump-iavl -d ~/.sei/data/committer.db -o /home/ubuntu/iavl-dump
+systemctl restart seid
+
+# For Legacy IAVL DB:
+seid debug dump-iavl <latest height>
+```
+
+Always include the app hash, commit hash, and block height from your logs when reporting issues.
+
+#### Crash and Panic Debugging
+
+For crashes, panics, or nil pointer exceptions:
+
+- Capture at least 1,000 lines of logs leading up to the crash
+- Or collect 15 minutes of log data, whichever provides more context
+- Include the full stack trace if available
+
+### Logging Configuration
+
+Proper logging configuration is essential for debugging and monitoring:
+
+```toml
+# In config.toml
+# Set appropriate log level
+log_level = "debug"  # Use "trace" for maximum detail
+
+# Choose log format
+log_format = "json"  # Use "plain" for human-readable logs
+```
+
+Configure log rotation to manage storage effectively:
+
+```bash
+# Example logrotate configuration
+sudo tee /etc/logrotate.d/seid << EOF
+/var/log/seid/*.log {
+    daily
+    rotate 14
+    compress
+    delaycompress
+    notifempty
+    create 0640 sei sei
+    sharedscripts
+    postrotate
+        systemctl reload seid
+    endscript
+}
+EOF
+```
+
+Enable core dumps for crash analysis:
+
+```bash
+# Set unlimited core dump size
+ulimit -c unlimited
+
+# Configure core dump location
+echo "/tmp/core.%e.%p" > /proc/sys/kernel/core_pattern
+```
 
 ## Recovery Procedures
 
+### Critical Warning: Double-Signing Prevention
+
+Double-signing is a severe violation that results in permanent validator tombstoning (irreversible jailing). Never run your validator keys on more than one machine simultaneously. If your primary validator goes offline:
+
+1. DO NOT start another validator with the same keys
+2. Either recover the original machine or properly migrate keys with absolute certainty the original is offline
+3. If unsure about the state of your original validator, seek support before proceeding
+
+The safe approach to recovery is:
+
+1. Diagnose why the original validator is offline
+2. If the original validator cannot be recovered, verify it is completely offline and powered down
+3. Only then proceed with key migration to a new machine
+
 ### Validator Recovery
 
-If you need to recover your validator on a new machine:
+When you need to recover your validator on a new machine, follow these steps carefully:
 
 ```bash
 # 1. Set up new machine with Sei node
@@ -580,10 +363,15 @@ gpg -d validator_key_backup.tar.gz.gpg | tar xzf -
 gpg -d keyring_backup.tar.gz.gpg | tar xzf -
 # 5. Start services
 sudo systemctl start seid
-sudo systemctl start price-feeder
 ```
 
-This guide provides a foundation for operating a Sei validator. Remember that
-validator operation requires constant attention to security, performance, and
-network participation. Stay engaged with the Sei community and keep updated with
-network developments.
+After recovery, verify your validator's status and performance:
+
+```bash
+# Check validator status
+seid status
+# Verify signing is working
+seid query slashing signing-info $(seid tendermint show-validator)
+```
+
+This guide provides a foundation for operating a Sei validator. Remember that validator operation requires constant attention to security, performance, and network participation. Stay engaged with the Sei community and keep updated with network developments.

--- a/pages/providers/wallets/wallets.mdx
+++ b/pages/providers/wallets/wallets.mdx
@@ -36,7 +36,7 @@ different features and levels of security.
 
 For more information on coin types and hierarchical deterministic (HD) paths as
 well as deriving wallet addresses properly, please refer to the
-[Advanced Concepts on HD Path Coin Types](dev-advanced-concepts/hd-path-coin-types).
+[Advanced Concepts on HD Path Coin Types](learn/hd-path-coin-types).
 
 ## Other Wallets
 

--- a/pages/reference/precompiles/example-usage.mdx
+++ b/pages/reference/precompiles/example-usage.mdx
@@ -40,7 +40,7 @@ const signer = await provider.getSigner();
 const contract = new ethers.Contract(WASM_PRECOMPILE_ADDRESS, WASM_PRECOMPILE_ABI, signer);
 ```
 
-<Callout type="info">If using MetaMask, the wallet must be switched to the Sei EVM Devnet chain. Learn how to import the Sei EVM Devnet chain [here](/setting-up-a-wallet).</Callout>
+<Callout type="info">If using MetaMask, the wallet must be switched to the Sei EVM Devnet chain. Information to import the Sei EVM Devnet chain can be found [here](../learn/wallet-setup).</Callout>
 
 #### Querying & Executing a CosmWasm Contract
 

--- a/pages/reference/precompiles/example-usage.mdx
+++ b/pages/reference/precompiles/example-usage.mdx
@@ -17,7 +17,7 @@ npm install @sei-js/evm
 ```
 
 Next, you'll need to use one of the precompiles in `EVM Precompiles` section. In
-this example, we're going to be using the [CosmWasm precompile](./cosmwasm.mdx):
+this example, we're going to be using the [CosmWasm precompile](reference/precompiles/cosmwasm):
 
 ```typescript copy
 // Import Wasm precompile address and ABI


### PR DESCRIPTION
Reorg to overall nodes or "operate" section
Major additions to validator's guide and the addition of a separate oracle price feeder guide
Correct some redundant header language and cleaned up page titles and section headers within several pages

TBD: build out monitoring+alerting section and remove any remaining references to this topic from main pages