### PR TITLE
Add Sei V2 EVM deployment height

### DIFF
--- a/content/evm/differences-with-ethereum.mdx
+++ b/content/evm/differences-with-ethereum.mdx
@@ -92,6 +92,22 @@ Sei's EVM and Ethereum itself:
   Interoperability between EVM and Cosmos-SDK modules is governed and navigated via [precompiles](./precompiles/example-usage) and [pointer contracts](./pointers/standard)
 </Callout>
 
+## Sei EVM Deployment
+
+Sei EVM was deployed at the following block heights and versions:
+
+### Testnet
+
+- **Name:** `v5.5.1`
+- **Height:** `90526031`
+- **Changelog:** https://github.com/sei-protocol/sei-chain/blob/main/CHANGELOG.md#v5.5.1
+
+### Mainnet
+
+- **Name:** `v5.5.2`
+- **Height:** `79123881`
+- **Changelog:** https://github.com/sei-protocol/sei-chain/blob/main/CHANGELOG.md#v552
+
 ## Opcode Differences
 
 ### PREVRANDAO


### PR DESCRIPTION
## What is the purpose of the change?

Add Sei V2 EVM deployment height for mainnet and testnet

## Describe the changes to the documentation

Added Sei V2 EVM deployment heights and changelogs and versions for mainnet and testnet

## Notes
<!-- Optional section for any other notes in this PR -->