### PR TITLE
change wallet examples installation scripts

### DIFF
--- a/content/evm/sei-global-wallet.mdx
+++ b/content/evm/sei-global-wallet.mdx
@@ -80,10 +80,10 @@ Below are integration examples for different frameworks and wallet provider libr
 <details>
   <summary><strong>RainbowKit Integration</strong></summary>
 
-**Create a new React app:**
+**Create a new Vite app:**
 
 ```bash copy
-npx create-react-app my-sei-dapp --template typescript
+npm create vite@latest my-sei-dapp -- --template react-ts
 cd my-sei-dapp
 ```
 
@@ -158,7 +158,7 @@ export default function App() {
 **Run Your App:**
 
 ```bash copy
-npm run start
+npm run dev
 ```
 
 </details>
@@ -166,10 +166,10 @@ npm run start
 <details>
   <summary><strong>ConnectKit Integration</strong></summary>
 
-**Create a new React app:**
+**Create a new Vite app:**
 
 ```bash copy
-npx create-react-app my-sei-dapp --template typescript
+npm create vite@latest my-sei-dapp -- --template react-ts
 cd my-sei-dapp
 ```
 
@@ -256,10 +256,10 @@ npm run dev
 <details>
   <summary><strong>Web3-React v8 Integration</strong></summary>
 
-**Create a new React app:**
+**Create a new Vite app:**
 
 ```bash
-npx create-react-app my-sei-dapp --template typescript
+npm create vite@latest my-sei-dapp -- --template react-ts
 cd my-sei-dapp
 ```
 
@@ -402,10 +402,10 @@ npm run dev
 <details>
   <summary><strong>Wagmi + Dynamic Integration</strong></summary>
 
-**Create a new React app:**
+**Create a new Vite app:**
 
 ```bash copy
-npx create-react-app my-sei-dapp --template typescript
+npm create vite@latest my-sei-dapp -- --template react-ts
 cd my-sei-dapp
 ```
 
@@ -550,7 +550,8 @@ cd my-sei-dapp
 ```bash copy
 npm install @dynamic-labs/sdk-react-core \
   @dynamic-labs/wagmi-connector wagmi viem \
-  @tanstack/react-query @sei-js/sei-global-wallet
+  @tanstack/react-query @sei-js/sei-global-wallet \
+  @dynamic-labs/ethereum
 ```
 
 **layout.tsx:**
@@ -560,7 +561,7 @@ npm install @dynamic-labs/sdk-react-core \
 
 import './globals.css';
 import { Inter } from 'next/font/google';
-import Providers from '@/lib/providers';
+import Providers from './lib/providers';
 const inter = Inter({ subsets: ['latin'] });
 
 // Import the global wallet implementation


### PR DESCRIPTION
## What is the purpose of the change?
Update existing documentation to use modern tooling

## Describe the changes to the documentation
Updated all wallet integration examples to use Vite instead of Create React App for project setup. Changed `npx create-react-app` commands to `npm create vite` equivalents across all integration guides. This provides users with matched dependencies.

## Notes
Vite offers significantly faster development server startup and HMR compared to CRA, it has more dependencies match and it has better bundler for sei-js making it the preferred choice for new React projects.