### PR TITLE
Add Workflow to automatically update changed files to the dataset

### DIFF
--- a/.github/workflows/update-trieve-dataset.yml
+++ b/.github/workflows/update-trieve-dataset.yml
@@ -1,0 +1,39 @@
+name: Update Trieve Dataset
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'content/**'
+      - 'app/**'
+      - 'scripts/**'
+  workflow_dispatch:
+
+jobs:
+  update-trieve:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build Next.js app
+        run: yarn build
+
+      - name: Run scrape-docs script
+        run: yarn scrape-docs
+
+      - name: Upload to Trieve
+        run: yarn upload-to-trieve
+        env:
+          TRIEVE_API_KEY: ${{ secrets.TRIEVE_API_KEY }}
+          TRIEVE_DATASET_ID: ${{ secrets.TRIEVE_DATASET_ID }}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+	testEnvironment: 'node',
+	testMatch: ['**/__tests__/**/*.test.js', '**/?(*.)+(spec|test).js'],
+	collectCoverageFrom: ['scripts/**/*.js', '!scripts/__tests__/**', '!**/node_modules/**'],
+	setupFilesAfterEnv: [],
+	verbose: true,
+	clearMocks: true,
+	resetMocks: true,
+	restoreMocks: true
+};

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
 		"generate-seid-docs": "./generate-seid-docs.sh",
 		"check-links": "node scripts/check-links.mjs",
 		"scrape-docs": "node scripts/scrape-docs-html.js",
+		"upload-to-trieve": "node scripts/upload-to-trieve.js",
+		"test": "jest",
+		"test:watch": "jest --watch",
 		"prepare": "husky"
 	},
 	"lint-staged": {
@@ -67,6 +70,9 @@
 		"concurrently": "^9.1.2",
 		"globby": "^14.1.0",
 		"husky": "^9.1.7",
+		"jest": "^29.7.0",
+		"jest-environment-node": "^29.7.0",
+		"jsdom": "^26.1.0",
 		"lint-staged": "^15.5.2",
 		"next-sitemap": "^4.2.3",
 		"node-fetch": "^3.3.2",

--- a/scripts/__tests__/upload-to-trieve.test.js
+++ b/scripts/__tests__/upload-to-trieve.test.js
@@ -1,0 +1,373 @@
+const fs = require('fs').promises;
+const path = require('path');
+const { uploadToTrieve } = require('../upload-to-trieve');
+
+// Mock fetch globally
+global.fetch = jest.fn();
+
+// Mock fs.readFile
+jest.mock('fs', () => ({
+	promises: {
+		readFile: jest.fn()
+	}
+}));
+
+describe('upload-to-trieve', () => {
+	const mockApiKey = 'test-api-key';
+	const mockDatasetId = 'test-dataset-id';
+	const mockScrapedData = [
+		{
+			title: 'Test Page 1',
+			url: 'https://docs.sei.io/test-page-1',
+			filePath: '/test/page1.html',
+			content: '<p>Test content 1</p>',
+			description: 'Test description 1',
+			keywords: ['test', 'page1']
+		},
+		{
+			title: 'Test Page 2',
+			url: 'https://docs.sei.io/learn/test-page-2',
+			filePath: '/test/page2.html',
+			content: '<p>Test content 2</p>',
+			description: 'Test description 2',
+			keywords: ['learn', 'page2']
+		}
+	];
+
+	const mockExistingFiles = [
+		{
+			id: 'file-1',
+			file_name: 'test-page-1.md',
+			size: 1000,
+			tag_set: ['sei-docs'],
+			metadata: {
+				content_hash: 'old-hash-1',
+				source: 'sei-docs'
+			}
+		},
+		{
+			id: 'file-2',
+			file_name: 'obsolete-page.md',
+			size: 500,
+			tag_set: ['sei-docs'],
+			metadata: {
+				content_hash: 'old-hash-2',
+				source: 'sei-docs'
+			}
+		}
+	];
+
+	beforeEach(() => {
+		// Set up environment variables
+		process.env.TRIEVE_API_KEY = mockApiKey;
+		process.env.TRIEVE_DATASET_ID = mockDatasetId;
+
+		// Reset mocks
+		jest.clearAllMocks();
+
+		// Mock console methods
+		jest.spyOn(console, 'log').mockImplementation(() => {});
+		jest.spyOn(console, 'error').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		// Clean up environment variables
+		delete process.env.TRIEVE_API_KEY;
+		delete process.env.TRIEVE_DATASET_ID;
+
+		// Restore console methods
+		console.log.mockRestore();
+		console.error.mockRestore();
+	});
+
+	describe('Environment Variables', () => {
+		test('should exit with error if TRIEVE_API_KEY is missing', async () => {
+			delete process.env.TRIEVE_API_KEY;
+			const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {});
+
+			await uploadToTrieve();
+
+			expect(mockExit).toHaveBeenCalledWith(1);
+			expect(console.error).toHaveBeenCalledWith('❌ Missing required environment variables:');
+
+			mockExit.mockRestore();
+		});
+
+		test('should exit with error if TRIEVE_DATASET_ID is missing', async () => {
+			delete process.env.TRIEVE_DATASET_ID;
+			const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {});
+
+			await uploadToTrieve();
+
+			expect(mockExit).toHaveBeenCalledWith(1);
+			expect(console.error).toHaveBeenCalledWith('❌ Missing required environment variables:');
+
+			mockExit.mockRestore();
+		});
+	});
+
+	describe('File Fetching', () => {
+		test('should successfully fetch existing files', async () => {
+			// Mock successful responses
+			fetch
+				.mockResolvedValueOnce({
+					ok: true,
+					json: () =>
+						Promise.resolve({
+							file_with_chunk_groups: mockExistingFiles,
+							next_cursor: null
+						})
+				}) // Fetch existing files
+				.mockResolvedValue({ ok: true }); // Other operations
+
+			// Mock file reading
+			fs.readFile.mockResolvedValue(JSON.stringify(mockScrapedData));
+
+			await uploadToTrieve();
+
+			// Verify scroll files API call
+			const scrollCall = fetch.mock.calls.find((call) => call[0].includes('/dataset/scroll_files'));
+			expect(scrollCall).toBeDefined();
+			expect(scrollCall[1].method).toBe('GET');
+			expect(scrollCall[1].headers['Authorization']).toBe(mockApiKey);
+			expect(scrollCall[1].headers['TR-Dataset']).toBe(mockDatasetId);
+		});
+
+		test('should handle fetch files API error', async () => {
+			fetch.mockResolvedValueOnce({
+				ok: false,
+				status: 403,
+				statusText: 'Forbidden'
+			});
+
+			const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {});
+
+			await uploadToTrieve();
+
+			expect(mockExit).toHaveBeenCalledWith(1);
+			expect(console.error).toHaveBeenCalledWith('❌ Error updating Trieve dataset:', expect.any(Error));
+
+			mockExit.mockRestore();
+		});
+	});
+
+	describe('Data Loading', () => {
+		test('should successfully load scraped data', async () => {
+			fetch
+				.mockResolvedValueOnce({ ok: true }) // Clear dataset
+				.mockResolvedValueOnce({ ok: true }); // Upload chunks
+
+			fs.readFile.mockResolvedValue(JSON.stringify(mockScrapedData));
+
+			await uploadToTrieve();
+
+			expect(fs.readFile).toHaveBeenCalledWith(path.join('./public/_scraped-docs', 'sei-docs-structured.json'), 'utf8');
+		});
+
+		test('should handle file reading error', async () => {
+			fetch.mockResolvedValueOnce({ ok: true }); // Clear dataset
+			fs.readFile.mockRejectedValue(new Error('File not found'));
+
+			const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {});
+
+			await uploadToTrieve();
+
+			expect(mockExit).toHaveBeenCalledWith(1);
+
+			mockExit.mockRestore();
+		});
+	});
+
+	describe('File Comparison', () => {
+		test('should identify files to create, update, and delete', async () => {
+			fetch
+				.mockResolvedValueOnce({
+					ok: true,
+					json: () =>
+						Promise.resolve({
+							file_with_chunk_groups: mockExistingFiles,
+							next_cursor: null
+						})
+				}) // Fetch existing files
+				.mockResolvedValue({ ok: true }); // Other operations
+
+			fs.readFile.mockResolvedValue(JSON.stringify(mockScrapedData));
+
+			await uploadToTrieve();
+
+			// Should identify files to upload (new + updated)
+			const uploadCalls = fetch.mock.calls.filter((call) => call[0].includes('/file') && call[1].method === 'POST');
+
+			// Should identify files to delete
+			const deleteCalls = fetch.mock.calls.filter((call) => call[0].includes('/file/') && call[1].method === 'DELETE');
+
+			// Expect at least some operations (exact count depends on content hashing)
+			expect(uploadCalls.length + deleteCalls.length).toBeGreaterThan(0);
+		});
+
+		test('should handle files without description or keywords', async () => {
+			const minimalData = [
+				{
+					title: 'Minimal Page',
+					url: 'https://docs.sei.io/minimal',
+					filePath: '/minimal.html',
+					content: '<p>Minimal content</p>'
+				}
+			];
+
+			fetch
+				.mockResolvedValueOnce({
+					ok: true,
+					json: () =>
+						Promise.resolve({
+							file_with_chunk_groups: [],
+							next_cursor: null
+						})
+				}) // Fetch existing files
+				.mockResolvedValue({ ok: true }); // Upload file
+
+			fs.readFile.mockResolvedValue(JSON.stringify(minimalData));
+
+			await uploadToTrieve();
+
+			const uploadCall = fetch.mock.calls.find((call) => call[0].includes('/file') && call[1].method === 'POST');
+
+			expect(uploadCall).toBeDefined();
+			const uploadBody = JSON.parse(uploadCall[1].body);
+
+			expect(uploadBody.metadata).not.toHaveProperty('description');
+			expect(uploadBody.metadata).not.toHaveProperty('keywords');
+			expect(uploadBody.tag_set).toEqual(['sei-docs']);
+		});
+	});
+
+	describe('File Upload', () => {
+		test('should upload files individually', async () => {
+			fetch
+				.mockResolvedValueOnce({
+					ok: true,
+					json: () =>
+						Promise.resolve({
+							file_with_chunk_groups: [],
+							next_cursor: null
+						})
+				}) // Fetch existing files (empty)
+				.mockResolvedValue({
+					ok: true,
+					json: () => Promise.resolve({ file_metadata: { id: 'new-file-id' } })
+				}); // Upload files
+
+			fs.readFile.mockResolvedValue(JSON.stringify(mockScrapedData));
+
+			await uploadToTrieve();
+
+			// Should have 1 fetch call + 2 upload calls (one for each scraped page)
+			const uploadCalls = fetch.mock.calls.filter((call) => call[0].includes('/file') && call[1].method === 'POST');
+
+			expect(uploadCalls).toHaveLength(2);
+
+			// Verify file upload structure
+			const firstUpload = JSON.parse(uploadCalls[0][1].body);
+			expect(firstUpload).toMatchObject({
+				file_name: expect.stringMatching(/\.md$/),
+				base64_file: expect.any(String),
+				create_chunks: true,
+				tag_set: expect.arrayContaining(['sei-docs']),
+				metadata: expect.objectContaining({
+					source: 'sei-docs',
+					content_hash: expect.any(String)
+				})
+			});
+		});
+
+		test('should handle upload API errors', async () => {
+			fetch
+				.mockResolvedValueOnce({
+					ok: true,
+					json: () =>
+						Promise.resolve({
+							file_with_chunk_groups: [],
+							next_cursor: null
+						})
+				}) // Fetch existing files
+				.mockResolvedValueOnce({
+					ok: false,
+					status: 400,
+					statusText: 'Bad Request',
+					text: () => Promise.resolve('Invalid file data')
+				});
+
+			fs.readFile.mockResolvedValue(JSON.stringify(mockScrapedData));
+
+			const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {});
+
+			await uploadToTrieve();
+
+			expect(mockExit).toHaveBeenCalledWith(1);
+			expect(console.error).toHaveBeenCalledWith('❌ Error updating Trieve dataset:', expect.any(Error));
+
+			mockExit.mockRestore();
+		});
+	});
+
+	describe('Success Flow', () => {
+		test('should complete full upload process successfully', async () => {
+			fetch
+				.mockResolvedValueOnce({
+					ok: true,
+					json: () =>
+						Promise.resolve({
+							file_with_chunk_groups: [],
+							next_cursor: null
+						})
+				}) // Fetch existing files
+				.mockResolvedValue({
+					ok: true,
+					json: () => Promise.resolve({ file_metadata: { id: 'file-id' } })
+				}); // Upload files
+
+			fs.readFile.mockResolvedValue(JSON.stringify(mockScrapedData));
+
+			await uploadToTrieve();
+
+			expect(console.log).toHaveBeenCalledWith('🚀 Starting intelligent Trieve file update...');
+			expect(console.log).toHaveBeenCalledWith('📄 Found 0 existing files');
+			expect(console.log).toHaveBeenCalledWith('📄 Found 2 pages to process');
+			expect(console.log).toHaveBeenCalledWith('✅ Successfully uploaded 2 files');
+			expect(console.log).toHaveBeenCalledWith('✅ Successfully updated Trieve dataset!');
+		});
+
+		test('should handle no changes scenario', async () => {
+			// Mock existing files that match current content
+			const matchingFiles = [
+				{
+					id: 'file-1',
+					file_name: 'test-page-1.md',
+					tag_set: ['sei-docs'],
+					metadata: {
+						content_hash: 'matching-hash', // This would match if content is identical
+						source: 'sei-docs'
+					}
+				}
+			];
+
+			fetch.mockResolvedValueOnce({
+				ok: true,
+				json: () =>
+					Promise.resolve({
+						file_with_chunk_groups: matchingFiles,
+						next_cursor: null
+					})
+			});
+
+			// Use minimal data to increase chance of no changes
+			fs.readFile.mockResolvedValue(JSON.stringify([mockScrapedData[0]]));
+
+			await uploadToTrieve();
+
+			// Should indicate analysis was performed
+			expect(console.log).toHaveBeenCalledWith('🔄 Analyzing file changes...');
+			expect(console.log).toHaveBeenCalledWith('📊 Analysis complete:');
+		});
+	});
+});

--- a/scripts/upload-to-trieve.js
+++ b/scripts/upload-to-trieve.js
@@ -1,0 +1,315 @@
+const fs = require('fs').promises;
+const path = require('path');
+
+// Configuration
+const TRIEVE_API_BASE = 'https://api.trieve.ai/api';
+const SCRAPED_DOCS_DIR = './public/_scraped-docs';
+const DELAY_BETWEEN_OPERATIONS = 500;
+
+async function uploadToTrieve() {
+	const apiKey = process.env.TRIEVE_API_KEY;
+	const datasetId = process.env.TRIEVE_DATASET_ID;
+
+	if (!apiKey || !datasetId) {
+		console.error('❌ Missing required environment variables: TRIEVE_API_KEY and TRIEVE_DATASET_ID must be set');
+		process.exit(1);
+	}
+
+	try {
+		console.log('🚀 Starting Trieve file update...');
+
+		console.log('📋 Fetching existing files from Trieve...');
+		const existingFiles = await getAllExistingFiles(apiKey, datasetId);
+		console.log(`📄 Found ${existingFiles.length} existing files`);
+
+		console.log('📖 Loading scraped documentation files...');
+		const scrapedFiles = await loadScrapedFiles();
+		console.log(`📄 Found ${scrapedFiles.length} files to process`);
+
+		console.log('🔄 Comparing files...');
+		const { toUpload, toDelete } = await compareFiles(existingFiles, scrapedFiles);
+
+		console.log(`📊 Analysis complete:`);
+		console.log(`   📤 ${toUpload.length} files to upload/update`);
+		console.log(`   🗑️  ${toDelete.length} files to delete`);
+
+		if (toUpload.length > 0) {
+			console.log('📤 Uploading/updating files...');
+			await uploadFiles(toUpload, apiKey, datasetId);
+		}
+
+		if (toDelete.length > 0) {
+			console.log('🗑️  Deleting obsolete files...');
+			await deleteFiles(toDelete, apiKey, datasetId);
+		}
+
+		if (toUpload.length === 0 && toDelete.length === 0) {
+			console.log('✨ No changes detected - dataset is up to date!');
+		} else {
+			console.log('✅ Successfully updated Trieve dataset!');
+		}
+	} catch (error) {
+		console.error('❌ Error updating Trieve dataset:', error);
+		process.exit(1);
+	}
+}
+
+async function getAllExistingFiles(apiKey, datasetId) {
+	console.log('🔍 Fetching existing files from Trieve...');
+	const allFiles = [];
+	let cursor = null;
+	let hasMore = true;
+	let pageCount = 0;
+	const maxPages = 50; // Safety limit
+
+	while (hasMore && pageCount < maxPages) {
+		pageCount++;
+		console.log(`   📄 Fetching page ${pageCount}...`);
+
+		const url = new URL(`${TRIEVE_API_BASE}/dataset/scroll_files`);
+		url.searchParams.append('page_size', '250');
+		if (cursor) {
+			url.searchParams.append('offset_file_id', cursor);
+		}
+
+		try {
+			const response = await fetch(url.toString(), {
+				method: 'GET',
+				headers: {
+					Authorization: apiKey,
+					'TR-Dataset': datasetId
+				}
+			});
+
+			if (!response.ok) {
+				throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+			}
+
+			const data = await response.json();
+			console.log(`   📄 Received ${data.file_with_chunk_groups?.length || 0} files`);
+
+			if (data.file_with_chunk_groups && data.file_with_chunk_groups.length > 0) {
+				allFiles.push(...data.file_with_chunk_groups);
+			}
+
+			if (cursor === data.next_cursor) {
+				console.log('   📄 Reached end of results');
+				hasMore = false;
+			} else {
+				cursor = data.next_cursor;
+			}
+
+			// Add delay to avoid rate limiting
+			await new Promise((resolve) => setTimeout(resolve, 100));
+		} catch (error) {
+			console.error(`   ❌ Error fetching page ${pageCount}:`, error.message);
+			break;
+		}
+	}
+
+	if (pageCount >= maxPages) {
+		console.log(`⚠️  Reached maximum page limit (${maxPages}), stopping fetch`);
+	}
+
+	console.log(`✅ Found ${allFiles.length} total files`);
+	return allFiles;
+}
+
+async function loadScrapedFiles() {
+	try {
+		const files = await fs.readdir(SCRAPED_DOCS_DIR);
+		const mdxFiles = files.filter((file) => file.endsWith('.mdx'));
+
+		const fileData = [];
+		for (const fileName of mdxFiles) {
+			const filePath = path.join(SCRAPED_DOCS_DIR, fileName);
+			const content = await fs.readFile(filePath, 'utf8');
+
+			fileData.push({
+				fileName: fileName.replace('.mdx', '.md'),
+				content,
+				filePath
+			});
+		}
+
+		return fileData;
+	} catch (error) {
+		throw new Error(`Failed to load scraped files: ${error.message}`);
+	}
+}
+
+async function compareFiles(existingFiles, scrapedFiles) {
+	const existingByFileName = new Map();
+
+	existingFiles.forEach((file) => {
+		existingByFileName.set(file.file_name.replace('.mdx', '.md'), file);
+	});
+
+	const toUpload = [];
+	const processedFileNames = new Set();
+
+	for (const fileData of scrapedFiles) {
+		const fileName = fileData.fileName.replace('.mdx', '.md');
+		processedFileNames.add(fileName);
+
+		const existingFile = existingByFileName.get(fileName);
+		const contentLength = fileData.content.length;
+
+		if (!existingFile) {
+			console.log(`   🆕 NEW: ${fileName}`);
+			toUpload.push({
+				fileName,
+				fileContent: fileData.content,
+				contentLength,
+				action: 'create'
+			});
+		} else {
+			// Check if content has changed by comparing content length
+			const existingLength = existingFile.metadata?.content_length;
+
+			if (existingLength !== contentLength) {
+				// Content has changed - needs to be updated
+				const reason = !existingLength ? 'no length stored' : 'content changed';
+				console.log(`   🔄 UPDATE: ${fileName} (${reason})`);
+				toUpload.push({
+					fileName,
+					fileContent: fileData.content,
+					contentLength,
+					action: 'update',
+					existingFileId: existingFile.id
+				});
+			} else {
+				console.log(`   ✅ SKIP: ${fileName} (unchanged)`);
+			}
+		}
+	}
+
+	// Find files to delete (exist in Trieve but not in scraped files)
+	const toDelete = [];
+	for (const [fileName, existingFile] of existingByFileName) {
+		if (!processedFileNames.has(fileName.replace('.mdx', '.md'))) {
+			toDelete.push(existingFile);
+		}
+	}
+
+	return { toUpload, toDelete };
+}
+
+async function uploadFiles(filesToUpload, apiKey, datasetId) {
+	let uploadedCount = 0;
+
+	for (const fileData of filesToUpload) {
+		try {
+			// If updating, delete the old file first
+			if (fileData.action === 'update') {
+				console.log(`🔄 Updating ${fileData.fileName}...`);
+				await deleteFile(fileData.existingFileId, apiKey, datasetId);
+				await delay(DELAY_BETWEEN_OPERATIONS);
+			} else {
+				console.log(`📤 Uploading ${fileData.fileName}...`);
+			}
+
+			// Upload the new/updated file
+			await uploadFile(fileData, apiKey, datasetId);
+			uploadedCount++;
+
+			// Add delay between uploads
+			await delay(DELAY_BETWEEN_OPERATIONS);
+		} catch (error) {
+			console.error(`❌ Failed to upload ${fileData.fileName}:`, error);
+			throw error;
+		}
+	}
+
+	console.log(`✅ Successfully uploaded ${uploadedCount} files`);
+}
+
+async function uploadFile(fileData, apiKey, datasetId) {
+	const base64Content = Buffer.from(fileData.fileContent).toString('base64');
+
+	const metadata = {
+		source: 'sei-docs',
+		content_length: fileData.contentLength,
+		scraped_at: new Date().toISOString()
+	};
+
+	const tagSet = ['sei-docs'];
+
+	// Use .md extension for consistency
+	const uploadFileName = fileData.fileName.replace('.mdx', '.md');
+
+	const requestBody = {
+		base64_file: base64Content,
+		file_name: uploadFileName,
+		description: `Documentation file: ${uploadFileName}`,
+		metadata: metadata,
+		tag_set: tagSet,
+		time_stamp: new Date().toISOString(),
+		create_chunks: true,
+		target_splits_per_chunk: 20,
+		split_delimiters: ['\n\n', '\n', '.', '!', '?']
+	};
+
+	const response = await fetch(`${TRIEVE_API_BASE}/file`, {
+		method: 'POST',
+		headers: {
+			Authorization: apiKey,
+			'Content-Type': 'application/json',
+			'TR-Dataset': datasetId
+		},
+		body: JSON.stringify(requestBody)
+	});
+
+	if (!response.ok) {
+		const errorText = await response.text();
+		throw new Error(`Failed to upload file: ${response.status} ${response.statusText}\n${errorText}`);
+	}
+
+	return await response.json();
+}
+
+async function deleteFiles(filesToDelete, apiKey, datasetId) {
+	let deletedCount = 0;
+
+	for (const file of filesToDelete) {
+		try {
+			console.log(`🗑️  Deleting ${file.file_name}...`);
+			await deleteFile(file.id, apiKey, datasetId);
+			deletedCount++;
+
+			// Add delay between deletions
+			await delay(DELAY_BETWEEN_OPERATIONS);
+		} catch (error) {
+			console.error(`❌ Failed to delete ${file.file_name}:`, error);
+			throw error;
+		}
+	}
+
+	console.log(`✅ Successfully deleted ${deletedCount} files`);
+}
+
+async function deleteFile(fileId, apiKey, datasetId) {
+	const response = await fetch(`${TRIEVE_API_BASE}/file/${fileId}?delete_chunks=true`, {
+		method: 'DELETE',
+		headers: {
+			Authorization: apiKey,
+			'TR-Dataset': datasetId
+		}
+	});
+
+	if (!response.ok) {
+		const errorText = await response.text();
+		throw new Error(`Failed to delete file: ${response.status} ${response.statusText}\n${errorText}`);
+	}
+}
+
+function delay(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Run the script
+if (require.main === module) {
+	uploadToTrieve();
+}
+
+module.exports = { uploadToTrieve };


### PR DESCRIPTION
## What is the purpose of the change?
This script intelligently uploads files to the sei-docs dataset in Trieve, which allows us to search easily in the MCP server and it matches the same system used by Mintlify for other docs. It includes tests to ensure this works properly.

## Describe the changes to the documentation
No documentation changes.

## Notes
Once this is live I will make a PR to `@sei-js/mcp-server` to update the dataset to use this one (without the html tags)