### PR TITLE
Switch GitHub actions to use `.nvmrc` file

### DIFF
--- a/.github/workflows/link_checker.yml
+++ b/.github/workflows/link_checker.yml
@@ -14,11 +14,12 @@ jobs:
   link-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: '.nvmrc'
 
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/update-trieve-dataset.yml
+++ b/.github/workflows/update-trieve-dataset.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version-file: '.nvmrc'
           cache: 'yarn'
 
       - name: Install dependencies

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch:
   pull_request:
 
-
 defaults:
   run:
     shell: bash
@@ -15,9 +14,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
 
       - name: Enable Corepack
         run: corepack enable


### PR DESCRIPTION
## What is the purpose of the change?

The rest of the repository uses NVM, so should the GitHub actions that verify things. Otherwise we could end up in a strange situation that is hard to debug.

## Describe the changes to the documentation

None