### PR TITLE
Replace GA with GTM - docs.sei.io

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,6 +12,8 @@ import 'nextra-theme-docs/style.css';
 import './globals.css';
 import 'katex/dist/katex.min.css';
 
+const GTM_ID = 'GTM-KKN784SR';
+
 export const metadata: Metadata = {
 	metadataBase: new URL('https://docs.sei.io'),
 	title: {
@@ -108,7 +110,7 @@ export default async function RootLayout({ children }) {
 				{/* Google Tag Manager (noscript) fallback */}
 				<noscript>
 					<iframe
-						src='https://www.googletagmanager.com/ns.html?id=GTM-KKN784SR'
+						src={`https://www.googletagmanager.com/ns.html?id=${GTM_ID}`}
 						height='0'
 						width='0'
 						style={{ display: 'none', visibility: 'hidden' }}
@@ -118,7 +120,7 @@ export default async function RootLayout({ children }) {
 				<Toaster position='bottom-left' />
 				<DocsProviders pageMap={await getPageMap()}>{children}</DocsProviders>
 			</body>
-			<GoogleTagManager gtmId='GTM-KKN784SR' />
+			<GoogleTagManager gtmId={GTM_ID} />
 		</html>
 	);
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { getPageMap } from 'nextra/page-map';
 import { Toaster } from 'sonner';
 import { Metadata } from 'next';
-import Script from 'next/script';
+import { GoogleTagManager } from '@next/third-parties/google';
 
 import DocsProviders from '../src/providers/DocsProviders';
 
@@ -105,19 +105,20 @@ export default async function RootLayout({ children }) {
 				/>
 			</head>
 			<body style={{ width: '100%', height: '100%' }}>
+				{/* Google Tag Manager (noscript) fallback */}
+				<noscript>
+					<iframe
+						src='https://www.googletagmanager.com/ns.html?id=GTM-KKN784SR'
+						height='0'
+						width='0'
+						style={{ display: 'none', visibility: 'hidden' }}
+						title='Google Tag Manager'
+					/>
+				</noscript>
 				<Toaster position='bottom-left' />
 				<DocsProviders pageMap={await getPageMap()}>{children}</DocsProviders>
 			</body>
-			{/* Google Analytics: lazy-load after window load */}
-			<Script src='https://www.googletagmanager.com/gtag/js?id=G-G33FDB53X5' strategy='lazyOnload' />
-			<Script id='ga-init' strategy='lazyOnload'>
-				{`
-					window.dataLayer = window.dataLayer || [];
-					function gtag(){dataLayer.push(arguments);}
-					gtag('js', new Date());
-					gtag('config', 'G-G33FDB53X5', { anonymize_ip: true });
-				`}
-			</Script>
+			<GoogleTagManager gtmId='GTM-KKN784SR' />
 		</html>
 	);
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 	"license": "MIT",
 	"dependencies": {
 		"@hcaptcha/react-hcaptcha": "^2.0.2",
+		"@next/third-parties": "^16.1.6",
 		"@radix-ui/themes": "^3.2.1",
 		"@sei-js/evm": "^2.0.5",
 		"@tabler/icons-react": "3.36.0",

--- a/src/components/FaucetRequest/index.tsx
+++ b/src/components/FaucetRequest/index.tsx
@@ -3,6 +3,7 @@
 import React, { useRef, useState, useCallback } from 'react';
 import { Button, Flex, Select } from '@radix-ui/themes';
 import { toast } from 'sonner';
+import { sendGTMEvent } from '@next/third-parties/google';
 import { IconDroplet, IconShieldCheck, IconHourglass, IconCheck, IconLoader2, IconExternalLink } from '@tabler/icons-react';
 import { isAddress } from 'viem/utils';
 import HCaptcha from '@hcaptcha/react-hcaptcha';
@@ -71,10 +72,7 @@ const RequestFaucetCard = () => {
 				const messageId = responseJson.data.messageId;
 				toast.success('Tokens requested successfully!');
 				startPolling(messageId, setTxHash);
-				if (typeof window !== 'undefined') {
-					const g = (window as any).gtag as undefined | ((...args: any[]) => void);
-					if (typeof g === 'function') g('event', 'faucetUsed', { address: destAddress });
-				}
+				sendGTMEvent({ event: 'faucet_used', address: destAddress });
 			} else if (responseJson.data?.nextAllowedUseDate) {
 				setNextUseTime(responseJson.data.nextAllowedUseDate);
 				toast.error(`Rate limited. Try again after ${responseJson.data.nextAllowedUseDate}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1376,6 +1376,13 @@
   resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.5.tgz#92c0161dec3c466b120a312199a376d029b92ce2"
   integrity sha512-7is37HJTNQGhjPpQbkKjKEboHYQnCgpVt/4rBrrln0D9nderNxZ8ZWs8w1fAtzUx7wEyYjQ+/13myFgFj6K2Ng==
 
+"@next/third-parties@^16.1.6":
+  version "16.1.6"
+  resolved "https://registry.yarnpkg.com/@next/third-parties/-/third-parties-16.1.6.tgz#366980adab28f808ce6142af6b474066e2ad49da"
+  integrity sha512-/cLY1egaH529ylSMSK+C8dA3nWDLL4hOFR4fca9OLWWxjcNwzsbuq2pPb/tmdWL9Zj3K1nTjd1pWQoSlaDQ0VA==
+  dependencies:
+    third-party-capital "1.0.20"
+
 "@noble/ciphers@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@noble/ciphers/-/ciphers-1.3.0.tgz#f64b8ff886c240e644e5573c097f86e5b43676dc"
@@ -8643,6 +8650,11 @@ text-decoder@^1.1.0:
   integrity sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==
   dependencies:
     b4a "^1.6.4"
+
+third-party-capital@1.0.20:
+  version "1.0.20"
+  resolved "https://registry.yarnpkg.com/third-party-capital/-/third-party-capital-1.0.20.tgz#e218a929a35bf4d2245da9addb8ab978d2f41685"
+  integrity sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==
 
 tinyexec@^0.3.2:
   version "0.3.2"


### PR DESCRIPTION
## What is the purpose of the change?
Replaces GA4 with GTM as part of an initiative to migrate from direct gtag.js to Google Tag Manager (GTM) across all Sei subdomains.