### PR TITLE
chore: update init command changes

### DIFF
--- a/content/node/index.mdx
+++ b/content/node/index.mdx
@@ -53,7 +53,7 @@ import Link from 'next/link';
     <div id="binary-versions" className="w-full">
       <h2 className="text-2xl font-bold text-neutral-800 dark:text-neutral-100 mb-4">Network Versions</h2>
       <div className="overflow-hidden rounded-lg border border-neutral-200 dark:border-neutral-800">
-        <VersionTable showGenesis={true} />
+        <VersionTable showGenesis={false} />
       </div>
     </div>
 
@@ -252,6 +252,10 @@ For more information see [here](https://pkg.go.dev/cmd/go#hdr-GOPATH_environment
               <div className="mb-4">
                 <h5 className="text-lg font-semibold text-neutral-800 dark:text-neutral-200 mb-3 mt-4">Initialize Chain Files</h5>
 
+<Callout type="info">
+Default init mode is **full** (RPC/P2P bind to all interfaces). For **validator** or **seed** nodes, use `--mode validator` or `--mode seed` so RPC and P2P bind to localhost only. See the [Validator Operations Guide](/node/validators) for the full validator init example.
+</Callout>
+
 Peers can be found here -
 
 - mainnet (pacific-1):
@@ -267,11 +271,11 @@ PEERS="b2664ccaa84a04b67683093fefb802b172ead6d1@sei-a2-rpc.p2p.brocha.in:30612,b
 ```
 
 ```bash copy
-# Initialize node
+# Initialize node (default mode is full: RPC/P2P bind to all interfaces)
+# For validator nodes, use: seid init <your-moniker> --chain-id <chain-id> --mode validator
 seid init <your-moniker> --chain-id <chain-id>
 
-# Get genesis file
-wget -O $HOME/.sei/config/genesis.json <genesis-file-url>
+# Genesis is written automatically for known networks (mainnet and testnets); no download needed.
 
 # Configure peers in config.toml.
 PEERS="<comma-separated-peer-list>"

--- a/content/node/validators.mdx
+++ b/content/node/validators.mdx
@@ -22,6 +22,16 @@ A validator in the Sei network serves several critical functions. As a validator
 
 ## Initial Setup
 
+### Initialize node
+
+Before key management and registration, initialize your node with validator mode so that RPC and P2P bind to localhost (recommended for validator security):
+
+```bash copy
+seid init <moniker> --chain-id <chain-id> --mode validator
+```
+
+The default init mode is **full**, which binds RPC and P2P to all interfaces (`0.0.0.0`). For validator (and seed) nodes, use `--mode validator` or `--mode seed` so that RPC and P2P listen on localhost only. Genesis is written automatically for known networks; no separate download is required.
+
 ### Key Management
 
 The security of your validator begins with proper key management. Your validator requires several distinct keys:


### PR DESCRIPTION
## What is the purpose of the change?

This PR prposes an update for node/validator docs: expresses that `init` cmd defaults to full mode (0.0.0.0), document `--mode validator` for localhost-only, and state that genesis is written by the binary for known networks (remove genesis download step and Genesis column from Network Versions table).

**Note:** Deploy this docs change when cutting a release on the `sei-chain` repo so the published docs match the new init/genesis behavior.

## Describe the changes to the documentation

<!-- A brief description of the changes in this PR and why they are required. If adding new content, be sure to detail the target audience of the new documentation-->

## Notes
<!-- Optional section for any other notes in this PR -->